### PR TITLE
avoid double remove file in close() of SelfCleanFP class

### DIFF
--- a/lib/vclib/svn/svn_ra.py
+++ b/lib/vclib/svn/svn_ra.py
@@ -180,7 +180,6 @@ class SelfCleanFP:
     self._fp = open(path, 'r')
     self._path = path
     self._eof = 0
-    self._closed = False
     
   def read(self, len=None):
     if len:
@@ -203,13 +202,16 @@ class SelfCleanFP:
     return lines
     
   def close(self):
-    self._closed = True
     self._fp.close()
-    os.remove(self._path)
+    if self._path:
+      try:
+        os.remove(self._path)
+        self._path = None
+      except OSError:
+        pass
 
   def __del__(self):
-    if not self._closed:
-      self.close()
+    self.close()
     
   def eof(self):
     return self._eof

--- a/lib/vclib/svn/svn_ra.py
+++ b/lib/vclib/svn/svn_ra.py
@@ -180,6 +180,7 @@ class SelfCleanFP:
     self._fp = open(path, 'r')
     self._path = path
     self._eof = 0
+    self._closed = False
     
   def read(self, len=None):
     if len:
@@ -202,11 +203,13 @@ class SelfCleanFP:
     return lines
     
   def close(self):
+    self._closed = True
     self._fp.close()
     os.remove(self._path)
 
   def __del__(self):
-    self.close()
+    if not self._closed:
+      self.close()
     
   def eof(self):
     return self._eof


### PR DESCRIPTION
`SelfCleanFP` class in `lib/vclib/svn/svn_ra.py` try to close fp and remove temporary file if the instance is deleted even if the fp is already closed and file is removed. (... and causes `OSError`,  which is ignored but logged in standalone mode).

This simple patch is to avoid it. 