### PR TITLE
Show stacktrace for exception other than ViewVCException if cfg.option.stacktraces=1

### DIFF
--- a/lib/debug.py
+++ b/lib/debug.py
@@ -109,6 +109,9 @@ def GetExceptionData():
     if isinstance(exc, ViewVCException):
       exc_dict['msg'] = exc.msg
       exc_dict['status'] = exc.status
+    elif isinstance(exc, Exception):
+      exc_dict['msg'] = str(exc)
+      exc_dict['status'] = '500 Internal Server Error'
 
     # Build a string from the formatted exception, but skipping the
     # first line.

--- a/lib/debug.py
+++ b/lib/debug.py
@@ -61,7 +61,7 @@ else:
   t_start = t_end = t_dump = lambda *args: None
 
 
-class ViewVCException:
+class ViewVCException(Exception):
   def __init__(self, msg, status=None):
     self.msg = msg
     self.status = status


### PR DESCRIPTION
For development and debugging, it is convenient if stacktrace can be shown other than ViewVCException.

This also make ViewVCException subclass of Exception (to prepare to support Python 3).
