### PR TITLE
trivial refactoring of vclib.svn (prepare to add svn commandline client based driver)

### DIFF
--- a/lib/vclib/svn/common_swig_py.py
+++ b/lib/vclib/svn/common_swig_py.py
@@ -1,0 +1,66 @@
+# -*-python-*-
+#
+# Copyright (C) 1999-2018 The ViewCVS Group. All Rights Reserved.
+#
+# By using this file, you agree to the terms and conditions set forth in
+# the LICENSE.html file which can be found at the top level of the ViewVC
+# distribution or at http://viewvc.org/license-1.html.
+#
+# For more information, visit http://viewvc.org/
+#
+# -----------------------------------------------------------------------
+
+"""commonly used functions and classes for Version Control lib driver
+for accessible Subversion repositories, using swib Python bindig for
+Subversion.
+"""
+
+from svn import core
+
+### Require Subversion 1.3.1 or better.
+if (core.SVN_VER_MAJOR, core.SVN_VER_MINOR, core.SVN_VER_PATCH) < (1, 3, 1):
+  raise Exception, "Version requirement not met (needs 1.3.1 or better)"
+
+### Pre-1.5 SubversionException's might not have the .msg and .apr_err members
+def _fix_subversion_exception(e):
+  if not hasattr(e, 'apr_err'):
+    e.apr_err = e[1]
+  if not hasattr(e, 'message'):
+    e.message = e[0]
+
+
+def _rev2optrev(rev):
+  assert isinstance(rev, (int, long))
+  rt = core.svn_opt_revision_t()
+  rt.kind = core.svn_opt_revision_number
+  rt.value.number = rev
+  return rt
+
+
+# Given a dictionary REVPROPS of revision properties, pull special
+# ones out of them and return a 4-tuple containing the log message,
+# the author, the date (converted from the date string property), and
+# a dictionary of any/all other revprops.
+def _split_revprops(revprops):
+  if not revprops:
+    return None, None, None, {}
+  special_props = []
+  for prop in core.SVN_PROP_REVISION_LOG, \
+              core.SVN_PROP_REVISION_AUTHOR, \
+              core.SVN_PROP_REVISION_DATE:
+    if revprops.has_key(prop):
+      special_props.append(revprops[prop])
+      del(revprops[prop])
+    else:
+      special_props.append(None)
+  msg, author, datestr = tuple(special_props)
+  date = _datestr_to_date(datestr)
+  return msg, author, date, revprops
+
+
+def _datestr_to_date(datestr):
+  try:
+    return core.svn_time_from_cstring(datestr) // 1000000
+  except:
+    return None
+

--- a/lib/vclib/svn/svn_common.py
+++ b/lib/vclib/svn/svn_common.py
@@ -1,0 +1,194 @@
+# -*-python-*-
+#
+# Copyright (C) 1999-2018 The ViewCVS Group. All Rights Reserved.
+#
+# By using this file, you agree to the terms and conditions set forth in
+# the LICENSE.html file which can be found at the top level of the ViewVC
+# distribution or at http://viewvc.org/license-1.html.
+#
+# For more information, visit http://viewvc.org/
+#
+# -----------------------------------------------------------------------
+
+"""commonly used functions and classes for Version Control lib driver
+for accessible Subversion repositories, without swig Python binding of
+Subversion.
+"""
+
+import sys
+import vclib
+
+# Python 3: workaround for cmp()
+if sys.version_info[0] >= 3:
+  def cmp(a, b):
+    return (a > b) - (a < b)
+
+
+def _path_parts(path):
+  return [pp for pp in path.split('/') if pp]
+
+
+def _getpath(path_parts):
+  return '/'.join(path_parts)
+
+def _cleanup_path(path):
+  """Return a cleaned-up Subversion filesystem path"""
+  return '/'.join([pp for pp in path.split('/') if pp])
+
+
+def _compare_paths(path1, path2):
+  path1_len = len (path1);
+  path2_len = len (path2);
+  min_len = min(path1_len, path2_len)
+  i = 0
+
+  # Are the paths exactly the same?
+  if path1 == path2:
+    return 0
+
+  # Skip past common prefix
+  while (i < min_len) and (path1[i] == path2[i]):
+    i = i + 1
+
+  # Children of paths are greater than their parents, but less than
+  # greater siblings of their parents
+  char1 = '\0'
+  char2 = '\0'
+  if (i < path1_len):
+    char1 = path1[i]
+  if (i < path2_len):
+    char2 = path2[i]
+
+  if (char1 == '/') and (i == path2_len):
+    return 1
+  if (char2 == '/') and (i == path1_len):
+    return -1
+  if (i < path1_len) and (char1 == '/'):
+    return -1
+  if (i < path2_len) and (char2 == '/'):
+    return 1
+
+  # Common prefix was skipped above, next character is compared to
+  # determine order
+  return cmp(char1, char2)
+
+
+class Revision(vclib.Revision):
+  "Hold state for each revision's log entry."
+  def __init__(self, rev, date, author, msg, size, lockinfo,
+               filename, copy_path, copy_rev):
+    vclib.Revision.__init__(self, rev, str(rev), date, author, None,
+                            msg, size, lockinfo)
+    self.filename = filename
+    self.copy_path = copy_path
+    self.copy_rev = copy_rev
+
+
+class SVNChangedPath(vclib.ChangedPath):
+  """Wrapper around vclib.ChangedPath which handles path splitting."""
+
+  def __init__(self, path, rev, pathtype, base_path, base_rev,
+               action, copied, text_changed, props_changed):
+    path_parts = _path_parts(path or '')
+    base_path_parts = _path_parts(base_path or '')
+    vclib.ChangedPath.__init__(self, path_parts, rev, pathtype,
+                               base_path_parts, base_rev, action,
+                               copied, text_changed, props_changed)
+
+
+class SubversionRepository(vclib.Repository):
+  def __init__(self, name, rootpath, authorizer, utilities, config_dir):
+    # Initialize some stuff.
+    self.rootpath = rootpath
+    self.name = name
+    self.auth = authorizer
+    self.diff_cmd = utilities.diff or 'diff'
+    self.config_dir = config_dir or None
+
+    # See if this repository is even viewable, authz-wise.
+    if not vclib.check_root_access(self):
+      raise vclib.ReposNotFound(name)
+
+  def rootname(self):
+    return self.name
+
+  def rootpath(self):
+    return self.rootpath
+
+  def roottype(self):
+    return vclib.SVN
+
+  def authorizer(self):
+    return self.auth
+
+  ### Subversion specific methods, but called from viewvc.py ###
+  def get_youngest_revision(self):
+    """returns youngest revision of the repository as int"""
+    return self.youngest
+
+  def get_location(self, path, rev, old_rev):
+    """returns location path of item specified by 'path' and 'rev' in 'old_rev'"""
+    raise UnsupportedFeature()
+
+  def created_rev(self, path, rev):
+    """returns first appeared revison of the item specified by 'path' and 'rev' as int"""
+    raise UnsupportedFeature()
+
+  def last_rev(self, path, peg_revision, limit_revision=None):
+    """Given PATH, known to exist in PEG_REVISION, find the youngest
+    revision older than, or equal to, LIMIT_REVISION in which path
+    exists.  Return that revision, and the path at which PATH exists in
+    that revision."""
+
+    # this is fallback implementation that first used svn_ra module
+    # that uses self.get_location() and binary search
+
+    # Here's the plan, man.  In the trivial case (where PEG_REVISION is
+    # the same as LIMIT_REVISION), this is a no-brainer.  If
+    # LIMIT_REVISION is older than PEG_REVISION, we can use Subversion's
+    # history tracing code to find the right location.  If, however,
+    # LIMIT_REVISION is younger than PEG_REVISION, we suffer from
+    # Subversion's lack of forward history searching.  Our workaround,
+    # ugly as it may be, involves a binary search through the revisions
+    # between PEG_REVISION and LIMIT_REVISION to find our last live
+    # revision.
+    peg_revision = self._getrev(peg_revision)
+    limit_revision = self._getrev(limit_revision)
+    if peg_revision == limit_revision:
+      return peg_revision, path
+    elif peg_revision > limit_revision:
+      path = self.get_location(path, peg_revision, limit_revision)
+      return limit_revision, path
+    else:
+      direction = 1
+      while peg_revision != limit_revision:
+        mid = (peg_revision + 1 + limit_revision) // 2
+        try:
+          path = self.get_location(path, peg_revision, mid)
+        except vclib.ItemNotFound:
+          limit_revision = mid - 1
+        else:
+          peg_revision = mid
+      return peg_revision, path
+
+  def get_symlink_target(self, path_parts, rev):
+    """Return the target of the symbolic link versioned at PATH_PARTS
+    in REV, or None if that object is not a symlink."""
+    raise UnsupportedFeature()
+
+  ## commonly used helper method
+
+  def _getrev(self, rev):
+    if rev is None or rev == 'HEAD':
+      return self.youngest
+    try:
+      if isinstance(rev, str):
+        while rev[0] == 'r':
+          rev = rev[1:]
+      rev = int(rev)
+    except:
+      raise vclib.InvalidRevision(rev)
+    if (rev < 0) or (rev > self.youngest):
+      raise vclib.InvalidRevision(rev)
+    return rev
+

--- a/lib/vclib/svn/svn_common.py
+++ b/lib/vclib/svn/svn_common.py
@@ -176,8 +176,6 @@ class SubversionRepository(vclib.Repository):
     in REV, or None if that object is not a symlink."""
     raise UnsupportedFeature()
 
-  ## commonly used helper method
-
   def _getrev(self, rev):
     if rev is None or rev == 'HEAD':
       return self.youngest
@@ -191,4 +189,3 @@ class SubversionRepository(vclib.Repository):
     if (rev < 0) or (rev > self.youngest):
       raise vclib.InvalidRevision(rev)
     return rev
-


### PR DESCRIPTION
  * move commonly used class and functions not using swig Python binding
    into svn_common.py

  * move commonly used functions using swig Python binding and API version
    check into common_swig_py.py

  * create common super class of LocalSubversionRepository and
    RemoteSubversionRepository (and may be CommandLineSubversionRepository)
    into svn_common.py

  * move _getpath() instance method into normal function in svn_common.py.
    (I think it can be provided by more upper module, though)

  * prepare to port to newer Python (keep Python 2.4 support)
    - use floor division operator in _datestr_to_date()
    - use isinstance() istead of extract type with type() in _getrev(), _rev2optrev(rev)