### PR TITLE
experimental commandline client 'svn' based Subversion repository access driver

### DIFF
--- a/lib/vclib/svn/__init__.py
+++ b/lib/vclib/svn/__init__.py
@@ -20,18 +20,22 @@ import urllib
 _re_url = re.compile('^(http|https|file|svn|svn\+[^:]+)://')
 
 def _canonicalize_path(path):
-  import svn.core
   try:
+    import svn.core
     return svn.core.svn_path_canonicalize(path)
-  except AttributeError: # svn_path_canonicalize() appeared in 1.4.0 bindings
-    # There's so much more that we *could* do here, but if we're
-    # here at all its because there's a really old Subversion in
-    # place, and those older Subversion versions cared quite a bit
-    # less about the specifics of path canonicalization.
-    if re.search(_re_url, path):
-      return path.rstrip('/')
-    else:
-      return os.path.normpath(path)
+  except (AttributeError, ImportError):
+    # svn_path_canonicalize() appeared in 1.4.0 bindings
+    # and it may be not available swig Python binding.
+    pass
+
+  # There's so much more that we *could* do here, but if we're
+  # here at all its because there's a really old Subversion in
+  # place, and those older Subversion versions cared quite a bit
+  # less about the specifics of path canonicalization.
+  if re.search(_re_url, path):
+    return path.rstrip('/')
+  else:
+    return os.path.normpath(path)
 
 
 def canonicalize_rootpath(rootpath):

--- a/lib/vclib/svn/svn_commandline.py
+++ b/lib/vclib/svn/svn_commandline.py
@@ -813,7 +813,10 @@ class CmdLineSubversionRepository(SubversionRepository):
       pass
     proc.stdout.close()
     proc.stderr.close()
-    rc = proc.wait()
+    if errout:
+      rc = proc.wait()
+    else:
+      rc = proc.poll()
     if rc:
       raise SvnCommandError(errout, cmd, rc)
     return text
@@ -840,7 +843,10 @@ class CmdLineSubversionRepository(SubversionRepository):
       pass
     proc.stdout.close()
     proc.stderr.close()
-    rc = proc.wait()
+    if errout:
+      rc = proc.wait()
+    else:
+      rc = proc.poll()
     if rc:
       raise SvnCommandError(errout, cmd, rc)
     return et

--- a/lib/vclib/svn/svn_commandline.py
+++ b/lib/vclib/svn/svn_commandline.py
@@ -529,7 +529,7 @@ class CmdLineSubversionRepository(SubversionRepository):
 
   def isexecutable(self, path_parts, rev):
     props = self.itemprops(path_parts, rev) # does authz-check
-    return props.has_key(SVN_PROP_EXECUTABLE)
+    return SVN_PROP_EXECUTABLE in props
 
   def filesize(self, path_parts, rev):
     path = _getpath(path_parts)

--- a/lib/vclib/svn/svn_commandline.py
+++ b/lib/vclib/svn/svn_commandline.py
@@ -1,0 +1,202 @@
+# -*-python-*-
+#
+# Copyright (C) 1999-2018 The ViewCVS Group. All Rights Reserved.
+#
+# By using this file, you agree to the terms and conditions set forth in
+# the LICENSE.html file which can be found at the top level of the ViewVC
+# distribution or at http://viewvc.org/license-1.html.
+#
+# For more information, visit http://viewvc.org/
+#
+# -----------------------------------------------------------------------
+
+"""Version Control lib driver to access Subversion repositories
+via commandline client 'svn'.
+"""
+
+import sys
+import xml.etree.ElementTree
+import subprocess
+if sys.version_info[0] >= 3:
+  PY3 = True
+  from urllib.parse import quote as _quote
+else:
+  from urllib import quote as _quote
+
+import vclib
+from . import _canonicalize_path
+from .common import SubversionRepository, Revision, SVNChangedPath, \
+                    _compare_paths, _path_parts, _getpath, _cleanup_path
+
+PY3 = (sys.version_info[0] >= 3)
+
+
+class SvnCommandError(vclib.Error):
+  def __init__(self, errout, cmd, retcode):
+    self.errout = errout
+    self.cmd = cmd
+    self.retcode = retcode
+    vclib.Error.__init__(self,
+                         ('svn %s exit with code %d: %s'
+                          %  (cmd, retcode, errout)))
+
+# here's a constants that cannot be retrived from library...
+SVN_PROP_PREFIX = "svn:"
+SVN_PROP_REVISION_AUTHOR = SVN_PROP_PREFIX + "author"
+SVN_PROP_REVISION_LOG = SVN_PROP_PREFIX + "log"
+SVN_PROP_REVISION_DATE = SVN_PROP_PREFIX + "date"
+SVN_PROP_SPECIAL = SVN_PROP_PREFIX + "special"
+SVN_PROP_EXECUTABLE = SVN_PROP_PREFIX + "executable"
+
+
+class CmdLineSubversionRepository(SubversionRepository):
+  def __init__(self, name, rootpath, authorizer, utilities, config_dir):
+    SubversionRepository.__init__(self, name, rootpath, authorizer, utilities,
+                                  config_dir)
+    self.svn_version = self.get_svn_version()
+
+  def open(self):
+
+    # get head revison of root
+    et = self.svn_cmd_xml('propget', ['--revprop', '-r', 'HEAD',
+                          SVN_PROP_REVISION_DATE, self.rootpath])
+    self.youngest = int(et.find('revprops').attrib['rev'])
+    self._dirent_cache = { }
+    self._revinfo_cache = { }
+
+    # See if a universal read access determination can be made.
+    if self.auth and self.auth.check_universal_access(self.name) == 1:
+      self.auth = None
+
+  def itemtype(self, path_parts, rev):
+    pathtype = None
+    if not len(path_parts):
+      pathtype = vclib.DIR
+    else:
+      url = self._geturl(_getpath(path_parts))
+      rev = self._getrev(rev)
+      try:
+        if self.svn_version >= (1, 9, 0) and False:
+          kind = self.svn_cmd('info', ['--depth=empty', '-r%s' % rev,
+                                       '--show-item=kind', '--no-newline',
+                                       url])
+        else:
+          et = self.svn_cmd_xml('info', ['--depth=empty', '-r%d' %rev, url])
+          kind = et.find('entry').attrib['kind']
+        if kind == 'file':
+          pathtype = vclib.FILE
+        elif kind == 'dir':
+          pathtype = vclib.DIR
+      except:
+        pass
+    if pathtype is None:
+      raise vclib.ItemNotFound(path_parts)
+    if not vclib.check_path_access(self, path_parts, pathtype, rev):
+      raise vclib.ItemNotFound(path_parts)
+    return pathtype
+
+
+  def openfile(self, path_parts, rev, options):
+    raise vclib.UnsupportedFeature()
+
+  def listdir(self, path_parts, rev, options):
+    raise vclib.UnsupportedFeature()
+
+  def dirlogs(self, path_parts, rev, entries, options):
+    raise vclib.UnsupportedFeature()
+
+  def itemlog(self, path_parts, rev, sortby, first, limit, options):
+    raise vclib.UnsupportedFeature()
+
+  def itemprops(self, path_parts, rev):
+    raise vclib.UnsupportedFeature()
+
+  def rawdiff(self, path_parts1, rev1, path_parts2, rev2, type, options={}):
+    raise vclib.UnsupportedFeature()
+
+  def annotate(self, path_parts, rev, include_text=False):
+    raise vclib.UnsupportedFeature()
+
+  def revinfo(self, rev):
+    raise vclib.UnsupportedFeature()
+
+  def isexecutable(self, path_parts, rev):
+    raise vclib.UnsupportedFeature()
+
+  def filesize(self, path_parts, rev):
+    raise vclib.UnsupportedFeature()
+
+  def get_youngest_revision(self):
+    return self.youngest
+
+  def get_location(self, path, rev, old_rev):
+    raise UnsupportedFeature()
+
+  def created_rev(self, path, rev):
+    raise UnsupportedFeature()
+
+  def get_symlink_target(self, path_parts, rev):
+    raise UnsupportedFeature()
+
+  ### helper functions ###
+
+  def _geturl(self, path=None):
+    if not path:
+      return self.rootpath
+    path = self.rootpath + '/' + _quote(path)
+    return _canonicalize_path(path)
+
+  def _do_svn_cmd(self, cmd, args, cfg=None):
+    """execute svn commandline utility and returns its proces object"""
+
+    # TODO: make an config option to specifiy subversion command line client
+    #       path and use it here.
+    svnpath='svn'
+    svn_cmd = [svnpath, cmd, '--non-interactive']
+    if self.config_dir:
+      svn_cmd.append('--config-dir=%s' % self.config_dir)
+    proc = subprocess.Popen(svn_cmd + list(args), bufsize=-1,
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                           close_fds=(sys.platform != "win32"))
+    return proc
+
+  def svn_cmd(self, cmd, args, cfg=None):
+    proc = self._do_svn_cmd(cmd, args, cfg)
+    text = proc.stdout.read()
+    proc.stdout.close()
+    rc = proc.poll()
+    if rc:
+      try:
+        errout = proc.stderr.read()
+      except Exception:
+        pass
+      raise SvnCommandError(errout, cmd, rc)
+    return text
+
+  def svn_cmd_fp(self, cmd, args, cfg=None):
+    proc = self._do_svn_cmd(cmd, args, cfg)
+    return proc.stdout
+
+  def svn_cmd_xml(self, cmd, args, cfg=None):
+    proc = self._do_svn_cmd(cmd, list(args) + ['--xml'], cfg)
+    try:
+      et = xml.etree.ElementTree.parse(proc.stdout)
+    except:
+      try:
+        errout = proc.stderr.read()
+      except Exception:
+        pass
+      rc = proc.poll()
+      if rc:
+        raise SvnCommandError(errout, cmd, rc)
+      else:
+        raise
+    return et
+
+  def get_svn_version(self):
+    version = self.svn_cmd('--version', ['--quiet'])
+    if version and version[-1:] == b'\n':
+      version = version[:-1]
+    version = tuple([int(x) for x in version.split(b'.')])
+    return version
+

--- a/lib/vclib/svn/svn_commandline.py
+++ b/lib/vclib/svn/svn_commandline.py
@@ -78,7 +78,11 @@ def _datestr_to_date(datestr, is_float=False):
   m = _re_iso8601.match(datestr)
   if m:
     ts = calendar.timegm(time.strptime(m.group('ts'), '%Y-%m-%dT%H:%M:%S'))
-    subsec = float(m.group('subsec'))
+    subsec = m.group('subsec')
+    if subsec is None:
+      subsec = 0.0
+    else:
+      subsec = float(subsec)
     if is_float:
       return float(ts) + subsec
     else:

--- a/lib/vclib/svn/svn_commandline.py
+++ b/lib/vclib/svn/svn_commandline.py
@@ -78,15 +78,12 @@ def _datestr_to_date(datestr, is_float=False):
   m = _re_iso8601.match(datestr)
   if m:
     ts = calendar.timegm(time.strptime(m.group('ts'), '%Y-%m-%dT%H:%M:%S'))
-    subsec = m.group('subsec')
-    if subsec is None:
-      subsec = 0.0
-    else:
-      subsec = float(subsec)
     if is_float:
-      return float(ts) + subsec
-    else:
-      return ts
+      ts = float(ts)
+      subsec = m.group('subsec')
+      if subsec is not None:
+        ts += float(subsec)
+    return ts
   else:
     # unknown format
     return None

--- a/lib/vclib/svn/svn_commandline.py
+++ b/lib/vclib/svn/svn_commandline.py
@@ -33,8 +33,8 @@ else:
   from urllib import quote as _quote
 
 import vclib
-from . import _canonicalize_path, _re_url
-from .svn_common import SubversionRepository, Revision, SVNChangedPath, \
+from __init__ import _canonicalize_path, _re_url
+from svn_common import SubversionRepository, Revision, SVNChangedPath, \
                         _compare_paths, _path_parts, _getpath, _cleanup_path
 
 

--- a/lib/vclib/svn/svn_commandline.py
+++ b/lib/vclib/svn/svn_commandline.py
@@ -508,7 +508,10 @@ class CmdLineSubversionRepository(SubversionRepository):
       revision = long(commit_elm.attrib['revision'])
       author = commit_elm.findtext('author')
       date = _datestr_to_date(commit_elm.findtext('date'))
-      line = fp.readline() if include_text else None
+      if include_test:
+        line = fp.readline()
+      else:
+        line = None
 
       prev_rev = None
       if revision > 1:

--- a/lib/vclib/svn/svn_common.py
+++ b/lib/vclib/svn/svn_common.py
@@ -1,0 +1,191 @@
+# -*-python-*-
+#
+# Copyright (C) 1999-2018 The ViewCVS Group. All Rights Reserved.
+#
+# By using this file, you agree to the terms and conditions set forth in
+# the LICENSE.html file which can be found at the top level of the ViewVC
+# distribution or at http://viewvc.org/license-1.html.
+#
+# For more information, visit http://viewvc.org/
+#
+# -----------------------------------------------------------------------
+
+"""commonly used functions and classes for Version Control lib driver
+for accessible Subversion repositories, without swig Python binding of
+Subversion.
+"""
+
+import sys
+import vclib
+
+# Python 3: workaround for cmp()
+if sys.version_info[0] >= 3:
+  def cmp(a, b):
+    return (a > b) - (a < b)
+
+
+def _path_parts(path):
+  return [pp for pp in path.split('/') if pp]
+
+
+def _getpath(path_parts):
+  return '/'.join(path_parts)
+
+def _cleanup_path(path):
+  """Return a cleaned-up Subversion filesystem path"""
+  return '/'.join([pp for pp in path.split('/') if pp])
+
+
+def _compare_paths(path1, path2):
+  path1_len = len (path1);
+  path2_len = len (path2);
+  min_len = min(path1_len, path2_len)
+  i = 0
+
+  # Are the paths exactly the same?
+  if path1 == path2:
+    return 0
+
+  # Skip past common prefix
+  while (i < min_len) and (path1[i] == path2[i]):
+    i = i + 1
+
+  # Children of paths are greater than their parents, but less than
+  # greater siblings of their parents
+  char1 = '\0'
+  char2 = '\0'
+  if (i < path1_len):
+    char1 = path1[i]
+  if (i < path2_len):
+    char2 = path2[i]
+
+  if (char1 == '/') and (i == path2_len):
+    return 1
+  if (char2 == '/') and (i == path1_len):
+    return -1
+  if (i < path1_len) and (char1 == '/'):
+    return -1
+  if (i < path2_len) and (char2 == '/'):
+    return 1
+
+  # Common prefix was skipped above, next character is compared to
+  # determine order
+  return cmp(char1, char2)
+
+
+class Revision(vclib.Revision):
+  "Hold state for each revision's log entry."
+  def __init__(self, rev, date, author, msg, size, lockinfo,
+               filename, copy_path, copy_rev):
+    vclib.Revision.__init__(self, rev, str(rev), date, author, None,
+                            msg, size, lockinfo)
+    self.filename = filename
+    self.copy_path = copy_path
+    self.copy_rev = copy_rev
+
+
+class SVNChangedPath(vclib.ChangedPath):
+  """Wrapper around vclib.ChangedPath which handles path splitting."""
+
+  def __init__(self, path, rev, pathtype, base_path, base_rev,
+               action, copied, text_changed, props_changed):
+    path_parts = _path_parts(path or '')
+    base_path_parts = _path_parts(base_path or '')
+    vclib.ChangedPath.__init__(self, path_parts, rev, pathtype,
+                               base_path_parts, base_rev, action,
+                               copied, text_changed, props_changed)
+
+
+class SubversionRepository(vclib.Repository):
+  def __init__(self, name, rootpath, authorizer, utilities, config_dir):
+    # Initialize some stuff.
+    self.rootpath = rootpath
+    self.name = name
+    self.auth = authorizer
+    self.diff_cmd = utilities.diff or 'diff'
+    self.config_dir = config_dir or None
+
+    # See if this repository is even viewable, authz-wise.
+    if not vclib.check_root_access(self):
+      raise vclib.ReposNotFound(name)
+
+  def rootname(self):
+    return self.name
+
+  def rootpath(self):
+    return self.rootpath
+
+  def roottype(self):
+    return vclib.SVN
+
+  def authorizer(self):
+    return self.auth
+
+  ### Subversion specific methods, but called from viewvc.py ###
+  def get_youngest_revision(self):
+    """returns youngest revision of the repository as int"""
+    return self.youngest
+
+  def get_location(self, path, rev, old_rev):
+    """returns location path of item specified by 'path' and 'rev' in 'old_rev'"""
+    raise UnsupportedFeature()
+
+  def created_rev(self, path, rev):
+    """returns first appeared revison of the item specified by 'path' and 'rev' as int"""
+    raise UnsupportedFeature()
+
+  def last_rev(self, path, peg_revision, limit_revision=None):
+    """Given PATH, known to exist in PEG_REVISION, find the youngest
+    revision older than, or equal to, LIMIT_REVISION in which path
+    exists.  Return that revision, and the path at which PATH exists in
+    that revision."""
+
+    # this is fallback implementation that first used svn_ra module
+    # that uses self.get_location() and binary search
+
+    # Here's the plan, man.  In the trivial case (where PEG_REVISION is
+    # the same as LIMIT_REVISION), this is a no-brainer.  If
+    # LIMIT_REVISION is older than PEG_REVISION, we can use Subversion's
+    # history tracing code to find the right location.  If, however,
+    # LIMIT_REVISION is younger than PEG_REVISION, we suffer from
+    # Subversion's lack of forward history searching.  Our workaround,
+    # ugly as it may be, involves a binary search through the revisions
+    # between PEG_REVISION and LIMIT_REVISION to find our last live
+    # revision.
+    peg_revision = self._getrev(peg_revision)
+    limit_revision = self._getrev(limit_revision)
+    if peg_revision == limit_revision:
+      return peg_revision, path
+    elif peg_revision > limit_revision:
+      path = self.get_location(path, peg_revision, limit_revision)
+      return limit_revision, path
+    else:
+      direction = 1
+      while peg_revision != limit_revision:
+        mid = (peg_revision + 1 + limit_revision) // 2
+        try:
+          path = self.get_location(path, peg_revision, mid)
+        except vclib.ItemNotFound:
+          limit_revision = mid - 1
+        else:
+          peg_revision = mid
+      return peg_revision, path
+
+  def get_symlink_target(self, path_parts, rev):
+    """Return the target of the symbolic link versioned at PATH_PARTS
+    in REV, or None if that object is not a symlink."""
+    raise UnsupportedFeature()
+
+  def _getrev(self, rev):
+    if rev is None or rev == 'HEAD':
+      return self.youngest
+    try:
+      if isinstance(rev, str):
+        while rev[0] == 'r':
+          rev = rev[1:]
+      rev = int(rev)
+    except:
+      raise vclib.InvalidRevision(rev)
+    if (rev < 0) or (rev > self.youngest):
+      raise vclib.InvalidRevision(rev)
+    return rev


### PR DESCRIPTION
This is an experimental implementation of Subversion repository access driver by using commandline client 'svn'.

I've tested on Python 2.7 with Subversion 1.11.0, but I'm not sure with older version of svn.
(I'll test with 1.8/1.9 client, but it is hard to test with more older version)

This is dropping Python 2.6+ and 3.x feature version, to try to keep Python 2.4+ compatibility. 