### PR TITLE
reduce redundant wrap for svn_stream_t in lib/vclib/svn/svn_ra.py

### DIFF
--- a/lib/vclib/svn/svn_ra.py
+++ b/lib/vclib/svn/svn_ra.py
@@ -167,12 +167,12 @@ class LogCollector:
     
 def cat_to_tempfile(svnrepos, path, rev):
   """Check out file revision to temporary file"""
-  temp = tempfile.mktemp()
-  stream = core.svn_stream_from_aprfile(temp)
+  fd, temp = tempfile.mkstemp()
+  fp = os.fdopen(fd, 'wb')
   url = svnrepos._geturl(path)
-  client.svn_client_cat(core.Stream(stream), url, _rev2optrev(rev),
+  client.svn_client_cat(fp, url, _rev2optrev(rev),
                         svnrepos.ctx)
-  core.svn_stream_close(stream)
+  fp.close()
   return temp
 
 class SelfCleanFP:


### PR DESCRIPTION
In swig Python bindings, wrappers for client, delta, diff, fs, ra, repos
APIs which require svn_stream_t * treat 'stream' parameter as file like
object regardlessly and wrap by using svn_swig_py_make_stream().
This behavor introduced Subversion r852660, before Subversion 1.3.0.

https://svn.apache.org/viewvc/subversion/tags/1.3.0/subversion/bindings/swig/include/svn_types.swg?revision=852660&view=markup#l336
https://svn.apache.org/viewvc?view=revision&revision=852660

So it is redundant to pass svn.Stream object to svn.client.svn_client_cat()

This PR reduce redandant wrap by passing file object created by using os.fdopen()
(This PR may conflict PR #159)