### PR TITLE
fix Python version check

### DIFF
--- a/lib/vclib/ccvs/bincvs.py
+++ b/lib/vclib/ccvs/bincvs.py
@@ -353,7 +353,7 @@ class BinCVSRepository(BaseCVSRepository):
     else:
       cmd = os.path.join(self.utilities.rcs_dir, rcs_cmd)
       args = rcs_args
-    if os.versioninfo[:2] >= (3, 3):
+    if sys.hexversion >= 0x3030000:
       stderr = subprocess.STDOUT if capture_err else subprocess.DEVNULL
     else:
       stderr = subprocess.STDOUT if capture_err else None


### PR DESCRIPTION
Note: This patch corrects error on Python version check , however if we supports only Python 3.3 and above, those version check conditionals themselves don't need.