### PR TITLE
issue #214: Fix exception after requests on StandaloneServer

### DIFF
--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -91,6 +91,14 @@ _URL_SAFE_CHARS = "/*~"
 def cmp(a, b):
   return (a > b) - (a < b)
 
+class TextIOWrapper_noclose(io.TextIOWrapper):
+  """Custom TextIOWrapper class which don't close underlaid IO object when
+  close() is called or this object is destroyed."""
+  def close(self):
+    if not self.closed:
+      self.closed = True
+      self.flush()
+      self.detach()
 
 class Request:
   def __init__(self, server, cfg):
@@ -958,7 +966,8 @@ def get_writeready_server_file(request, content_type=None, encoding=None,
     fp = request.server.file()
 
   if is_text:
-    fp = io.TextIOWrapper(fp, 'utf-8', 'surrogateescape', write_through=True)
+    fp = TextIOWrapper_noclose(fp, 'utf-8', 'surrogateescape',
+                               write_through=True)
 
   return fp
 

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -92,7 +92,7 @@ def cmp(a, b):
   return (a > b) - (a < b)
 
 class TextIOWrapper_noclose(io.TextIOWrapper):
-  """Custom TextIOWrapper class which don't close underlaid IO object when
+  """Custom TextIOWrapper class which doesn't close underlaying IO object when
   close() is called or this object is destroyed."""
   def close(self):
     if not self.closed:


### PR DESCRIPTION
As the caller of viewvc.run_viewvc() does't expect that the server output
stream when the function returns.  However the text wrapper object created
in get_writeready_server_file() closed the stream when viewvc.run_viewvc()
returned, by the destructor of the wrapper object.  That's why
StandAloneServer reported ValueError Exception.  So we use custom wrapper
object not to close underlaid stream when the close() is called or the
object is removed.

* lib/viewvc.py
  (TextIOwrapper_noclose):
    New child class of io.TextIOWrapper. This never call close() on
    underlaid stream.
  (get_writeready_server_file):
    Use TextIOwrapper_noclose() instead of io.TextIOWrapper.