### PR TITLE
Fix svnauthz to work in Python 3

### DIFF
--- a/lib/vcauth/svnauthz/__init__.py
+++ b/lib/vcauth/svnauthz/__init__.py
@@ -14,10 +14,7 @@
 import vcauth
 import os.path
 from common import ViewVCException
-try:
-    from configparser import ConfigParser
-except ImportError:
-    from ConfigParser import ConfigParser
+from configparser import ConfigParser
 
 
 class ViewVCAuthorizer(vcauth.GenericViewVCAuthorizer):

--- a/lib/vcauth/svnauthz/__init__.py
+++ b/lib/vcauth/svnauthz/__init__.py
@@ -14,7 +14,10 @@
 import vcauth
 import os.path
 from common import ViewVCException
-from ConfigParser import ConfigParser
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
 
 
 class ViewVCAuthorizer(vcauth.GenericViewVCAuthorizer):


### PR DESCRIPTION
- Import `ConfigParser` from `configparser` instead of `ConfigParser` since that is how to do it in Python 3.