### PR TITLE
Ease a ref-count leakage due to edit baton on Subversion swig-py.

### DIFF
--- a/lib/vclib/svn/svn_repos.py
+++ b/lib/vclib/svn/svn_repos.py
@@ -678,6 +678,8 @@ class LocalSubversionRepository(vclib.Repository):
                     found_readable = 1
                 else:
                     found_unreadable = 1
+            # Workaround for ref-count leak due to delta make_editor()
+            editor.__dict__.clear()
             return found_readable, found_unreadable, list(changedpaths.values())
 
         def _get_change_copyinfo(fsroot, path, change):


### PR DESCRIPTION
A reference count leakage of Python object found in delta editor
API on Subversion's SWIG Python bindings [1][2][3]. An edit baton
C structure created by delta.make_editor() hold a reference for the
editor object and never release even after the proxy object is
deleted, so editor object never deallocated by Python interpreter.
To ease the impact, especialy for standalone server and for mod_wsgi
server, we release all attributes hold by editor object before
release its reference in function frame.

[1] https://trac.edgewall.org/ticket/13112
[2] https://trac.edgewall.org/ticket/13129#comment:6
[3] https://trac.edgewall.org/ticket/13356#comment:6

* lib/vclib/svn/svn_repos.py
  (LocalSubversionRepository._revinfo._get_changed_paths):
    Release all attributes of editor object before exit the function frame.
