### PR TITLE
issue #257: Try to avoid double-HTML-escaping error information

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -78,6 +78,8 @@ class ViewVCException(Exception):
 
 
 def print_exception_data(server, exc_data):
+    """Print the exception data to the server output stream.  Details are expected
+    to be already HTML-escaped."""
     status = exc_data["status"]
     msg = exc_data["msg"]
     tb = exc_data["stacktrace"]
@@ -87,12 +89,12 @@ def print_exception_data(server, exc_data):
 
     fp = io.TextIOWrapper(server.file(), "utf-8", "xmlcharrefreplace", write_through=True)
     fp.write("<h3>An Exception Has Occurred</h3>\n")
-    s = msg and "<p><pre>%s</pre></p>" % (server.escape(msg)) or ""
+    s = msg and f"<p><pre>{msg}</pre></p>" or ""
     if status:
-        s = s + ("<h4>HTTP Response Status</h4>\n<p><pre>\n%s</pre></p><hr />\n" % status)
+        s = s + (f"<h4>HTTP Response Status</h4>\n<p><pre>\n{status}</pre></p><hr />\n")
     fp.write(s)
     fp.write("<h4>Python Traceback</h4>\n<p><pre>")
-    fp.write(server.escape(tb))
+    fp.write(tb)
     fp.write("</pre></p>\n")
 
 

--- a/lib/sapi.py
+++ b/lib/sapi.py
@@ -103,7 +103,7 @@ class Server:
     def start_response(self, content_type, status):
         """Start a response.  Child classes should extend this method."""
         if self._response_started:
-            raise ServerUsageError()
+            raise ServerUsageError("Server response has already been started")
         self._response_started = True
 
     def escape(self, s):


### PR DESCRIPTION
While here, try to fix problems with bytes/str streams, too.

* `lib/common.py`: (print_exception_data): Don't escape strings -- let callers manage that.
* `lib/sapi.py`: (start_response): Add a message when raising ServerUsageError().
* `lib/viewvc.py`: (view_error): When generating error output through the template system, don't escape error strings.  But if we fall back to the print-to-stream direct approach, do.