### PR TITLE
issue #272: ccvs module: Fix issue on checkout caused by adding incomplete line.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Version 1.3.0 (released ??-???-????)
   * removed deprecated checkout_magic option/behavior (#215)
   * new 'allow_mojibake' option (#216)
   * require explicit match for web-friendly images in 'binary_mime_types' (#216)
+  * fix a problem on CVS checkout files with rcsparse (#272)
 
 Version 1.2.1 (released 26-Mar-2020)
 


### PR DESCRIPTION
It seems some CVS implementation can produce RCS diff outputs that
add an incomplete line which is not terminated by LF code.
However our code didn't care whether the lines are complete or not.

To fix it, we treat "text" in StreamText, without removing trailing LF code.

* lib/vclib/ccvs/ccvs.py
  (CCVSRepository.openfile):
    Connect contents of StreamText without completion of LF.
  (_msplit): New.
  (StreamText.d_command, StreamText.a_command): Be stricter.
  (StreamText.__init__, StreamText.command):
    Don't assume LF code for each end of lines.