### PR TITLE
issue #272: ccvs module: Fix the issue on checkout caused by adding incomplete line.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Version 1.2.2 (released ??-???-????)
 
   * standalone.py defaults to UTF-8 output now, too
   * fix viewvc-install error handling bug
+  * fix a problem on CVS checkout files with rcsparse (#272)
 
 Version 1.2.1 (released 26-Mar-2020)
 


### PR DESCRIPTION
* lib/vclib/ccvs/ccvs.py
  (CCVSRepository.openfile):
    Connect contents of StreamText without completion of LF.
  (_msplit): New.
  (StreamText.d_command, StreamText.a_command): Be stricter.
  (StreamText.__init__, StreamText.command):
    Don't assume LF code for each end of lines.

* CHANGES
  Note this change.