### PR TITLE
Fix 'Revision Graph' for CVS repository to work with Python 3

### DIFF
--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -3251,10 +3251,9 @@ def view_cvsgraph_image(request):
             request.repos.rootpath,
             cvsgraph_extraopts(request),
             rcsfile,
-            "| base64",
         ),
     )
-    copy_stream(fp, get_writeready_server_file(request, "image/png", "base64"))
+    copy_stream(fp, get_writeready_server_file(request, "image/png"))
     fp.close()
 
 

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -3251,9 +3251,10 @@ def view_cvsgraph_image(request):
             request.repos.rootpath,
             cvsgraph_extraopts(request),
             rcsfile,
+            "| base64",
         ),
     )
-    copy_stream(fp, get_writeready_server_file(request, "image/png"))
+    copy_stream(fp, get_writeready_server_file(request, "image/png", "base64"))
     fp.close()
 
 
@@ -3307,6 +3308,7 @@ def view_cvsgraph(request):
             cvsgraph_extraopts(request),
             rcsfile,
         ),
+        is_text=True,
     )
 
     graph_action, graph_hidden_values = request.get_form(view_func=view_cvsgraph, params={})


### PR DESCRIPTION
This is my first ever pull-request on GitHub so please be gentle with me:)

The 'Revision Graph' for a CVS file throws the following exception:

```
 File "/var/lib/viewvc/lib/viewvc.py", line 5524, in main
    request.run_viewvc()
 File "/var/lib/viewvc/lib/viewvc.py", line 457, in run_viewvc
    self.view_func(self)
 File "/var/lib/viewvc/lib/viewvc.py", line 3339, in view_cvsgraph
    generate_page(request, "graph", data)
 File "/var/lib/viewvc/lib/viewvc.py", line 1024, in generate_page
    template.generate(server_fp, data)
 File "/var/lib/viewvc/lib/ezt.py", line 347, in generate
    self._execute(self.program, fp, ctx)
 File "/var/lib/viewvc/lib/ezt.py", line 524, in _execute
    method(method_args, fp, ctx, filename, line_number)
 File "/var/lib/viewvc/lib/ezt.py", line 540, in _cmd_print
    fp.write(chunk)
 TypeError: write() argument must be str, not bytes
```

This occurs when the output from the `popen()` for `cvsgraph` is copied to the HTTP response from the `view_cvsgraph()` and `view_cvsgraph_image()` functions.

For `view_cvsgraph()` I have changed the `popen()` to text mode. For `view_cvsgraph_image()` I have piped the output through the `base64` utility and set the content-type encoding accordingly.

There is probably a better fix but this seemed like the simplest solution.

```
diff --git a/lib/viewvc.py b/lib/viewvc.py
index 121140a2..e6fb3c96 100644
--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -3251,9 +3251,10 @@ def view_cvsgraph_image(request):
             request.repos.rootpath,
             cvsgraph_extraopts(request),
             rcsfile,
+            "| base64",
         ),
     )
-    copy_stream(fp, get_writeready_server_file(request, "image/png"))
+    copy_stream(fp, get_writeready_server_file(request, "image/png", "base64"))
     fp.close()
 
 
@@ -3307,6 +3308,7 @@ def view_cvsgraph(request):
             cvsgraph_extraopts(request),
             rcsfile,
         ),
+        is_text=True,
     )
 
     graph_action, graph_hidden_values = request.get_form(view_func=view_cvsgraph, params={})
```

