### PR TITLE
Fix issue #288: cmp() workaround cannot handle None input

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -28,6 +28,18 @@ class _item:
         vars(self).update(kw)
 
 
+# Python 3: workaround for cmp()
+def cmp(a, b):
+    if a is None and b is None:
+        return 0
+    if a is None:
+        return 1
+    if b is None:
+        return -1
+    assert type(a) == type(b)
+    return (a > b) - (a < b)
+
+
 class TemplateData:
     """A custom dictionary-like object that allows one-time definition
     of keys, and only value fetches and changes, and key deletions,

--- a/lib/vclib/ccvs/bincvs.py
+++ b/lib/vclib/ccvs/bincvs.py
@@ -22,11 +22,7 @@ import calendar
 import subprocess
 import vclib.ccvs
 import functools
-
-
-# Python 3: workaround for cmp()
-def cmp(a, b):
-    return (a > b) - (a < b)
+from common import cmp
 
 
 def enc_decode(s, encoding="utf-8"):

--- a/lib/vclib/svn/svn_repos.py
+++ b/lib/vclib/svn/svn_repos.py
@@ -19,6 +19,7 @@ import tempfile
 from io import StringIO
 from urllib.parse import quote as _quote
 from svn import fs, repos, core, client, delta
+from common import cmp
 
 long = int
 
@@ -62,11 +63,6 @@ def _cleanup_path(path):
 
 def _fs_path_join(base, relative):
     return _cleanup_path(base + "/" + relative)
-
-
-# Python 3 workaround for cmp()
-def cmp(a, b):
-    return (a > b) - (a < b)
 
 
 def _compare_paths(path1, path2):

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -55,6 +55,7 @@ import vcauth
 import vclib
 import vclib.ccvs
 import vclib.svn
+from common import cmp
 
 try:
     import idiff
@@ -91,11 +92,6 @@ CHUNK_SIZE = 8192
 
 # special characters that don't need to be URL encoded
 _URL_SAFE_CHARS = "/*~"
-
-
-# Python 3: workaround for cmp()
-def cmp(a, b):
-    return (a > b) - (a < b)
 
 
 class TextIOWrapper_noclose(io.TextIOWrapper):


### PR DESCRIPTION
Python2's `cmp()` function no longer exists in Python3, so when we converted to Python3 we reproduced the seemingly relevant bits of `cmp()` as a utility method.  Unfortunately, the naive suggestion from Python's own upgrade docs:

    def cmp(a, b):
        return (a > b) - (a < b)

...is a bit *too* naive.  Python2's `cmp()` supports `None` input values as well as comparisons between differing types of input values.  We don't need the latter, but it seems in some cases we do need the former.  So this change trades multiple replicas of the naive `cmp()` workaround for a single shared slightly-less-naive implementation that handles `None` inputs the way Python2's `cmp()` does.