### PR TITLE
Follow up to issue #288: Remove _compare_paths() to reduce the use of cmp()

### DIFF
--- a/lib/vclib/svn/svn_repos.py
+++ b/lib/vclib/svn/svn_repos.py
@@ -65,43 +65,6 @@ def _fs_path_join(base, relative):
     return _cleanup_path(base + "/" + relative)
 
 
-def _compare_paths(path1, path2):
-    path1_len = len(path1)
-    path2_len = len(path2)
-    min_len = min(path1_len, path2_len)
-    i = 0
-
-    # Are the paths exactly the same?
-    if path1 == path2:
-        return 0
-
-    # Skip past common prefix
-    while (i < min_len) and (path1[i] == path2[i]):
-        i = i + 1
-
-    # Children of paths are greater than their parents, but less than
-    # greater siblings of their parents
-    char1 = "\0"
-    char2 = "\0"
-    if i < path1_len:
-        char1 = path1[i]
-    if i < path2_len:
-        char2 = path2[i]
-
-    if (char1 == "/") and (i == path2_len):
-        return 1
-    if (char2 == "/") and (i == path1_len):
-        return -1
-    if (i < path1_len) and (char1 == "/"):
-        return -1
-    if (i < path2_len) and (char2 == "/"):
-        return 1
-
-    # Common prefix was skipped above, next character is compared to
-    # determine order
-    return cmp(char1, char2)
-
-
 def _rev2optrev(rev):
     assert isinstance(rev, int)
     rt = core.svn_opt_revision_t()


### PR DESCRIPTION
We used `cmp()` for sorting by using `list.sort()` or `sorted()` functions in Python 2, and we rewrite it for sorting functions in Python 3 by using `functools.cmp_to_key()`.  However it can be simple if we can write the `key` function for sorting which provides a sort key retrieving from each sorting items directly.

In the case in `svn_ra.py`, we were sorting the paths both in bytes and str form by using function `_compare_paths()` as comparison function for `list.sort()`.  However it can be rewritten by using sorting function with `split()` function as a key function for sorting().  As they were the only usage of `_compare_paths()`,   we can remove the function `_compare_paths()` after replacing it.