### PR TITLE
Follow up to issue #288: Remove _logsort_date_cmp and _logsort_rev_cmp to reduce the use of cmp()

### DIFF
--- a/lib/vclib/ccvs/bincvs.py
+++ b/lib/vclib/ccvs/bincvs.py
@@ -21,8 +21,7 @@ import re
 import calendar
 import subprocess
 import vclib.ccvs
-import functools
-from common import cmp
+from operator import attrgetter
 
 
 def enc_decode(s, encoding="utf-8"):
@@ -320,10 +319,11 @@ class BinCVSRepository(BaseCVSRepository):
         filtered_revs = _file_log(revs, tags, lockinfo, default_branch, rev)
 
         options["cvs_tags"] = tags
+        # Both of Revision.date and Revision.number are sortable, not None
         if sortby == vclib.SORTBY_DATE:
-            filtered_revs.sort(key=functools.cmp_to_key(_logsort_date_cmp))
+            filtered_revs.sort(key=attrgetter('date', 'number'), reverse=True)
         elif sortby == vclib.SORTBY_REV:
-            filtered_revs.sort(key=functools.cmp_to_key(_logsort_rev_cmp))
+            filtered_revs.sort(key=attrgetter('number'), reverse=True)
 
         if len(filtered_revs) < first:
             return []
@@ -429,16 +429,6 @@ class Tag:
 
 # ======================================================================
 # Functions for dealing with Revision and Tag objects
-
-
-def _logsort_date_cmp(rev1, rev2):
-    # sort on date; secondary on revision number
-    return -cmp(rev1.date, rev2.date) or -cmp(rev1.number, rev2.number)
-
-
-def _logsort_rev_cmp(rev1, rev2):
-    # sort highest revision first
-    return -cmp(rev1.number, rev2.number)
 
 
 def _match_revs_tags(revlist, taglist):

--- a/lib/vclib/ccvs/ccvs.py
+++ b/lib/vclib/ccvs/ccvs.py
@@ -14,7 +14,7 @@ import os
 import re
 import tempfile
 from io import BytesIO
-import functools
+from operator import attrgetter
 import vclib
 from . import rcsparse
 from . import blame
@@ -27,8 +27,6 @@ from .bincvs import (
     Tag,
     _file_log,
     _log_path,
-    _logsort_date_cmp,
-    _logsort_rev_cmp,
     _path_join,
 )
 
@@ -112,10 +110,11 @@ class CCVSRepository(BaseCVSRepository):
                 rev.changed = rev.prev.next_changed
         options["cvs_tags"] = sink.tags
 
+        # Both of Revision.date and Revision.number are sortable, not None
         if sortby == vclib.SORTBY_DATE:
-            filtered_revs.sort(key=functools.cmp_to_key(_logsort_date_cmp))
+            filtered_revs.sort(key=attrgetter('date', 'number'), reverse=True)
         elif sortby == vclib.SORTBY_REV:
-            filtered_revs.sort(key=functools.cmp_to_key(_logsort_rev_cmp))
+            filtered_revs.sort(key=attrgetter('number'), reverse=True)
 
         if len(filtered_revs) < first:
             return []


### PR DESCRIPTION
In bincvs.py and ccvs.py, we used _logsort_date_cmp() and
_logsort_rev_cmp() as cmp parameter for list.sort() method in Python 2,
for sorting CVS logs.  However it can be done by using key parameter for
list.sort(), with operator.attrgetter(), as "Sorting HOW TO"[1] document
shows.

So we use it and then remove _logsort_date_cmp and _logsort_rev_cmp
functions.

[1] https://docs.python.org/3/howto/sorting.html

* lib/vclib/ccvs/bincvs.py
  (_logsort_date_cmp, _logsort_rev_cmp): Removed.

* lib/vclib/ccvs/bincvs.py (BinCVSRepository.itemlog),
  lib/vclib/ccvs/ccvs.py (CCVSRepository.itemlog):
    Use operator.attrgetter() as key parameter for sorting.