### PR TITLE
Follow up to issue #288: Use native key function in sort in viewvc.py

### DIFF
--- a/lib/vclib/__init__.py
+++ b/lib/vclib/__init__.py
@@ -246,6 +246,14 @@ class DirEntry:
         self.kind = kind
         self.errors = errors
 
+    def sortkey(self, attrname, default=''):
+        """Get attribute value specified for sort key
+
+        If the attribute value is None, return default value instead.
+        """
+        v = getattr(self, attrname)
+        return v if v is not None else default
+
 
 class Revision:
     """Instances holds information about revisions of versioned resources"""

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -2318,8 +2318,9 @@ def sort_file_data(file_data, roottype, sortdir, sortby, group_dirs):
                 # file2 is a directory, it sorts first.
                 return 1 if not reverse else -1
 
-        # we should have data on these. if not, then it is because we requested
-        # a specific tag and that tag is not present on the file.
+        # If the file does not have revision data, which can be only in
+        # "cvs" roottype, the file should been placed after those files
+        # which have revision data, ...
         if file1.rev is not None and file2.rev is not None:
             return file_sort_sortby(file1, file2, sortby)
         elif file1.rev is not None:
@@ -2327,7 +2328,8 @@ def sort_file_data(file_data, roottype, sortdir, sortby, group_dirs):
         elif file2.rev is not None:
             return 1 if not reverse else -1
 
-        # sort by file name
+        # ... and then those should be sorted by its name after the files
+        # which have revison data.
         return cmp(file1.name, file2.name)
 
     file_data.sort(key=functools.cmp_to_key(file_sort_cmp), reverse=reverse)

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -2331,11 +2331,6 @@ def sort_file_data(file_data, roottype, sortdir, sortby, group_dirs):
     file_data.sort(key=functools.cmp_to_key(file_sort_cmp))
 
 
-def icmp(x, y):
-    """case insensitive comparison"""
-    return cmp(x.lower(), y.lower())
-
-
 def view_roots(request):
     if "roots" not in request.cfg.options.allowed_views:
         raise ViewVCException("Root listing view is disabled", "403 Forbidden")
@@ -2345,7 +2340,7 @@ def view_roots(request):
     expand_root_parents(request.cfg)
     allroots = list_roots(request)
     if len(allroots):
-        rootnames = sorted(allroots.keys(), key=functools.cmp_to_key(icmp))
+        rootnames = sorted(allroots.keys(), key=str.lower)
         for rootname in rootnames:
             root_path, root_type, lastmod = allroots[rootname]
             href = request.get_url(
@@ -2654,13 +2649,13 @@ def view_directory(request):
     # set cvs-specific fields
     if request.roottype == "cvs":
         plain_tags = options["cvs_tags"]
-        plain_tags.sort(key=functools.cmp_to_key(icmp), reverse=True)
+        plain_tags.sort(key=str.lower, reverse=True)
         data["plain_tags"] = []
         for plain_tag in plain_tags:
             data["plain_tags"].append(_item(name=plain_tag, revision=None))
 
         branch_tags = options["cvs_branches"]
-        branch_tags.sort(key=functools.cmp_to_key(icmp), reverse=True)
+        branch_tags.sort(key=str.lower, reverse=True)
         data["branch_tags"] = []
         for branch_tag in branch_tags:
             data["branch_tags"].append(_item(name=branch_tag, revision=None))

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -2294,11 +2294,12 @@ def sort_file_data(file_data, roottype, sortdir, sortby, group_dirs):
         if sortby == "rev":
             return revcmp(file1.rev, file2.rev)
         elif sortby == "date":
-            return cmp(file2.date, file1.date)  # latest date is first
+            # latest date is first
+            return cmp(file2.sortkey('date', -1), file1.sortkey('date', -1))
         elif sortby == "log":
-            return cmp(file1.log, file2.log)
+            return cmp(file1.sortkey('log'), file2.sortkey('log'))
         elif sortby == "author":
-            return cmp(file1.author, file2.author)
+            return cmp(file1.sortkey('author'), file2.sortkey('author'))
         return cmp(file1.name, file2.name)
 
     def file_sort_cmp(file1, file2, sortby=sortby, group_dirs=group_dirs):

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -32,6 +32,7 @@ import struct
 import tempfile
 import time
 import functools
+from operator import attrgetter
 import io
 import popen
 from urllib.parse import urlencode as _urlencode, quote as _quote
@@ -1089,7 +1090,7 @@ def prep_tags(request, tags):
     for tag in tags:
         href = url + tag.name
         links.append(_item(name=tag.name, href=href))
-    links.sort(key=functools.cmp_to_key(lambda a, b: cmp(a.name, b.name)))
+    links.sort(key=attrgetter('name'))
     return links
 
 
@@ -4205,7 +4206,7 @@ def generate_tarball(out, request, reldir, stack, dir_mtime=None):
     rep_path = request.path_parts + reldir
     entries = request.repos.listdir(rep_path, request.pathrev, {})
     request.repos.dirlogs(rep_path, request.pathrev, entries, {})
-    entries.sort(key=functools.cmp_to_key(lambda a, b: cmp(a.name, b.name)))
+    entries.sort(key=attrgetter('name'))
 
     # figure out corresponding path in tar file. everything gets put underneath
     # a single top level directory named after the repository directory being
@@ -4425,10 +4426,7 @@ def view_revision(request):
         props.append(_item(name=name, value=value, undisplayable=ezt.boolean(undisplayable)))
 
     # Sort the changes list by path.
-    def changes_sort_by_path(a, b):
-        return cmp(a.path_parts, b.path_parts)
-
-    changes.sort(key=functools.cmp_to_key(changes_sort_by_path))
+    changes.sort(key=attrgetter('path_parts'))
 
     # Handle limit_changes parameter
     cfg_limit_changes = cfg.options.limit_changes

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -2281,8 +2281,8 @@ def revcmp(rev1, rev2):
 
 
 def sort_file_data(file_data, roottype, sortdir, sortby, group_dirs):
-    # convert sortdir into a sign bit
-    s = sortdir == "down" and -1 or 1
+    # convert sortdir into reverse parameter in sort() method
+    reverse = (sortdir == "down")
 
     # in cvs, revision numbers can't be compared meaningfully between
     # files, so try to do the right thing and compare dates instead
@@ -2292,16 +2292,16 @@ def sort_file_data(file_data, roottype, sortdir, sortby, group_dirs):
     def file_sort_sortby(file1, file2, sortby):
         # sort according to sortby
         if sortby == "rev":
-            return s * revcmp(file1.rev, file2.rev)
+            return revcmp(file1.rev, file2.rev)
         elif sortby == "date":
-            return s * cmp(file2.date, file1.date)  # latest date is first
+            return cmp(file2.date, file1.date)  # latest date is first
         elif sortby == "log":
-            return s * cmp(file1.log, file2.log)
+            return cmp(file1.log, file2.log)
         elif sortby == "author":
-            return s * cmp(file1.author, file2.author)
-        return s * cmp(file1.name, file2.name)
+            return cmp(file1.author, file2.author)
+        return cmp(file1.name, file2.name)
 
-    def file_sort_cmp(file1, file2, sortby=sortby, group_dirs=group_dirs, s=s):
+    def file_sort_cmp(file1, file2, sortby=sortby, group_dirs=group_dirs):
         # if we're grouping directories together, sorting is pretty
         # simple.  a directory sorts "higher" than a non-directory, and
         # two directories are sorted as normal.
@@ -2312,24 +2312,24 @@ def sort_file_data(file_data, roottype, sortdir, sortby, group_dirs):
                     return file_sort_sortby(file1, file2, sortby)
                 else:
                     # file1 is a directory, it sorts first.
-                    return -1
+                    return -1 if not reverse else 1
             elif file2.kind == vclib.DIR:
                 # file2 is a directory, it sorts first.
-                return 1
+                return 1 if not reverse else -1
 
         # we should have data on these. if not, then it is because we requested
         # a specific tag and that tag is not present on the file.
         if file1.rev is not None and file2.rev is not None:
             return file_sort_sortby(file1, file2, sortby)
         elif file1.rev is not None:
-            return -1
+            return -1 if not reverse else 1
         elif file2.rev is not None:
-            return 1
+            return 1 if not reverse else -1
 
         # sort by file name
-        return s * cmp(file1.name, file2.name)
+        return cmp(file1.name, file2.name)
 
-    file_data.sort(key=functools.cmp_to_key(file_sort_cmp))
+    file_data.sort(key=functools.cmp_to_key(file_sort_cmp), reverse=reverse)
 
 
 def view_roots(request):


### PR DESCRIPTION
When we ported ViewVC into Python 3,  we use cmp_to_key() function to porting old usage of sorted() / list.sort() function into Python 3 style sorting using key keyword parameter.  However it has disadvantage in performance.

With these commits, I rewrote those cmp functions based key function into native key functions.