### PR TITLE
Issue 293 check diff error

### DIFF
--- a/lib/vclib/__init__.py
+++ b/lib/vclib/__init__.py
@@ -15,7 +15,6 @@ such as CVS.
 """
 
 import sys
-import io
 import subprocess
 import os
 import time
@@ -376,6 +375,12 @@ class NonTextualFileContents(Error):
     pass
 
 
+class ExternalDiffError(Error):
+    def __init__(self, returncode, mess):
+        self.returncode = returncode
+        Error.__init__(self, "Diff terminated with exit code {0:d}: {1}".format(returncode, mess))
+
+
 # ======================================================================
 # Implementation code used by multiple vclib modules
 
@@ -427,26 +432,41 @@ class _diff_fp:
         if info1 and info2:
             args.extend(["-L", self._label(info1), "-L", self._label(info2)])
         args.extend([temp1, temp2])
+        # We assume pipe buffer for stderr is enough for diff utility,
+        # otherwise, it may cause deadlock.
         self.proc = subprocess.Popen(
-            args, stdout=subprocess.PIPE, bufsize=-1, close_fds=(sys.platform != "win32")
+            args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            encoding="utf-8", errors="surrogateescape",
+            bufsize=-1, close_fds=(sys.platform != "win32")
         )
-        if not isinstance(self.proc.stdout, io.TextIOBase) and isinstance(
-            self.proc.stdout, io.BufferedIOBase
-        ):
-            self.fp = io.TextIOWrapper(self.proc.stdout, encoding="utf-8", errors="surrogateescape")
-        else:
-            self.fp = self.proc.stdout
 
-    def read(self, bytes):
-        return self.fp.read(bytes)
+    def read(self, buf_size):
+        buf = self.proc.stdout.read(buf_size)
+        if buf == "":
+            errs = self.proc.stderr.read()
+            ret = self.proc.poll()
+            if ret not in (None, 0, 1) or errs:
+                if ret is None:
+                    ret = -1
+                raise ExternalDiffError(ret, errs)
+        return buf
 
     def readline(self):
-        return self.fp.readline()
+        buf = self.proc.stdout.readline()
+        if buf == "":
+            errs = self.proc.stderr.read()
+            ret = self.proc.poll()
+            if ret not in (None, 0, 1) or errs:
+                if ret is None:
+                    ret = -1
+                raise ExternalDiffError(ret, errs)
+        return buf
 
     def close(self):
         try:
             if self.proc:
-                self.fp.close()
+                self.proc.stdout.close()
+                self.proc.stderr.close()
                 ret = self.proc.poll()
                 if ret is None:
                     # child process seems to be still running...

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -3612,9 +3612,12 @@ def diff_parse_headers(fp, diff_type, path1, path2, rev1, rev2, sym1=None, sym2=
         parsing = 1
         flag = _RCSDIFF_NO_CHANGES
         while parsing:
-            line = fp.readline()
-            if not line:
-                break
+            try:
+                line = fp.readline()
+                if not line:
+                    break
+            except vclib.ExternalDiffError as e:
+                raise ViewVCException(str(e), "500 Internal Server Error")
 
             # Saw at least one line in the stream
             flag = None


### PR DESCRIPTION
This is a part of fix of #293. With these changes, ViewVC will be able to report errors on executing external diff utility.