### PR TITLE
issue #293: Make diff --unified option parameter configurable.

### DIFF
--- a/conf/viewvc.conf.dist
+++ b/conf/viewvc.conf.dist
@@ -339,13 +339,12 @@
 ## max_context: Number of context lines to pass to diff program with
 ## "--unified" option, for "Full human readable" format.
 ##
-## The GNU diff utility does not have option to get whole context
-## or unified diffs without omission.  Alternatively, we indicate
-## large number of context lines practically enough.
-##
-## The default value is 10000, which is large enough for diff text
-## on web browser, we think. You can increase or decrease this value
-## as long as the diff utility can accept it.
+## The GNU diff utility does not have the option to request all the context
+## of unified diffs, so the best we can do is to ask for a very large
+## number of context lines.  The default value is 10000, which should be
+## large enough to result in the display of all context lines for any files
+## whose diffs you'd care to even see in a web browser.  Of course, you can
+## increase or decrease this value as best suits your server.
 ##
 #max_context = 10000
 
@@ -638,7 +637,7 @@
 ##   c      Context diff
 ##   s      Side by side
 ##   l      Long human readable (more context)
-##   f      Full human readable (very large context, entire file in most case)
+##   f      Full human readable (very large context, entire file in most cases)
 ##
 #diff_format = h
 

--- a/conf/viewvc.conf.dist
+++ b/conf/viewvc.conf.dist
@@ -336,6 +336,19 @@
 ##
 #diff = 
 
+## max_context: Number of context lines to pass to diff program with
+## "--unified" option, for "Full human readable" format.
+##
+## The GNU diff utility does not have option to get whole context
+## or unified diffs without omission.  Alternatively, we indicate
+## large number of context lines practically enough.
+##
+## The default value is 10000, which is large enough for diff text
+## on web browser, we think. You can increase or decrease this value
+## as long as the diff utility can accept it.
+##
+#max_context = 10000
+
 ## cvsgraph: Location of the CvsGraph program, a graphical CVS version
 ## graph generator (see options.use_cvsgraph).
 ##
@@ -625,7 +638,7 @@
 ##   c      Context diff
 ##   s      Side by side
 ##   l      Long human readable (more context)
-##   f      Full human readable (entire file)
+##   f      Full human readable (very large context, entire file in most case)
 ##
 #diff_format = h
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -387,6 +387,7 @@ class Config:
         else:
             self.utilities.cvsnt = None
         self.utilities.diff = ""
+        self.utilities.max_context = 10000
         self.utilities.cvsgraph = ""
 
         self.options.root_as_url_component = 1

--- a/lib/vclib/__init__.py
+++ b/lib/vclib/__init__.py
@@ -390,18 +390,12 @@ def _diff_args(type, options):
     args = []
     if type == CONTEXT:
         if "context" in options:
-            if options["context"] is None:
-                args.append("--context=-1")
-            else:
-                args.append("--context=%i" % options["context"])
+            args.append("--context=%i" % options["context"])
         else:
             args.append("-c")
     elif type == UNIFIED:
         if "context" in options:
-            if options["context"] is None:
-                args.append("--unified=-1")
-            else:
-                args.append("--unified=%i" % options["context"])
+            args.append("--unified=%i" % options["context"])
         else:
             args.append("-u")
     elif type == SIDE_BY_SIDE:

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -3856,7 +3856,7 @@ class DiffDescription:
         self.line_differ = None
         self.fp_differ = None
         self.request = request
-        self.context = -1
+        self.context = None
         self.changes = []
 
         if self.diff_format == "c":
@@ -3871,7 +3871,7 @@ class DiffDescription:
             self.human_readable = 1
         elif self.diff_format == "f":
             self.diff_type = vclib.UNIFIED
-            self.context = None
+            self.context = cfg.utilities.max_context
             self.human_readable = 1
         elif self.diff_format == "h":
             self.diff_type = vclib.UNIFIED
@@ -3922,7 +3922,7 @@ class DiffDescription:
     def get_content_diff(self, left, right):
         options = self.request.cfg.options
         diff_options = {}
-        if self.context != -1:
+        if self.context is not None:
             diff_options["context"] = self.context
         if self.human_readable or self.diff_format == "u":
             diff_options["funout"] = options.hr_funout
@@ -3933,7 +3933,7 @@ class DiffDescription:
 
     def get_prop_diff(self, left, right):
         diff_options = {}
-        if self.context != -1:
+        if self.context is not None:
             diff_options["context"] = self.context
         if self.human_readable:
             cfg = self.request.cfg


### PR DESCRIPTION
* `conf/viewvc.conf.dist`
  (`utilities.max_context`):
      New option
  (`options.diff_format`):
      In comment, excuse "Full human readable" is not truely "full"

* `lib/config.py`
  (`Config.set_defaults`):
      Set default value for new option "utilities.max_context"

* `lib/vclib/__init__.py`
  (`_diff_args`):
      Remove special case of options["context"] is None. It should be set an integer value now.

* `lib/viewvc.py` 
  (`DiffDescription.__init__`, `DiffDescription.get_content_diff`,
  `DiffDescription.get_prop_diff`):
      Use None instead of -1 for the flag DiffDescription.context is not set.
  (`DiffDescription.__init__`):
      Set config "`utilities.max_context`" value as context option value for "Full human readable" diff format.