### PR TITLE
Issue #275: Fix unified and side-by-side diff view in the case hr_intraline = 1

### DIFF
--- a/lib/ezt.py
+++ b/lib/ezt.py
@@ -583,7 +583,7 @@ class Template:
 
     def _cmd_if_index(self, args, fp, ctx, filename, line_number):
         ((valref, value), t_section, f_section) = args
-        list, idx = ctx.for_index[valref[0]]
+        vlist, idx = ctx.for_index[valref[0]]
         if value == "even":
             value = idx % 2 == 0
         elif value == "odd":
@@ -591,7 +591,7 @@ class Template:
         elif value == "first":
             value = idx == 0
         elif value == "last":
-            value = idx == len(list) - 1
+            value = idx == len(vlist) - 1
         else:
             value = idx == int(value)
         self._do_if(value, t_section, f_section, fp, ctx)
@@ -616,12 +616,12 @@ class Template:
 
     def _cmd_for(self, args, fp, ctx, filename, line_number):
         ((valref,), unused, section) = args
-        list = _get_value(valref, ctx, filename, line_number)
+        vlist = _get_value(valref, ctx, filename, line_number)
         refname = valref[0]
-        if isinstance(list, str):
+        if isinstance(vlist, str):
             raise NeedSequenceError(refname, filename, line_number)
-        ctx.for_index[refname] = idx = [list, 0]
-        for item in list:
+        ctx.for_index[refname] = idx = [vlist, 0]
+        for item in vlist:
             self._execute(section, fp, ctx)
             idx[1] = idx[1] + 1
         del ctx.for_index[refname]
@@ -706,8 +706,8 @@ def _get_value(refname_start_rest, ctx, filename, line_number):
 
     # get the starting object
     if start in ctx.for_index:
-        list, idx = ctx.for_index[start]
-        ob = list[idx]
+        vlist, idx = ctx.for_index[start]
+        ob = vlist[idx]
     elif start in ctx.defines:
         ob = ctx.defines[start]
     elif hasattr(ctx.data, start):

--- a/lib/ezt.py
+++ b/lib/ezt.py
@@ -730,6 +730,8 @@ def _get_value(refname_start_rest, ctx, filename, line_number):
 
     # string or a sequence
     if hasattr(ob, '__next__'):
+        # The return value ob should not be an iterator or a generator,
+        # because it would be accessed via index later.
         return list(ob)
     return ob
 

--- a/lib/ezt.py
+++ b/lib/ezt.py
@@ -729,6 +729,8 @@ def _get_value(refname_start_rest, ctx, filename, line_number):
         return ""
 
     # string or a sequence
+    if hasattr(ob, '__next__'):
+        return list(ob)
     return ob
 
 

--- a/lib/vclib/__init__.py
+++ b/lib/vclib/__init__.py
@@ -174,7 +174,7 @@ class Repository:
           funout - boolean, include C function names
           ignore_white - boolean, ignore whitespace
 
-        Return value is a python file object
+        Return value is a file like object with str I/O.
         """
 
     def annotate(self, path_parts, rev, include_text=False):
@@ -420,8 +420,8 @@ def _diff_args(type, options):
 
 
 class _diff_fp:
-    """File object reading a diff between temporary files, cleaning up
-    on close"""
+    """File like object with str I/O reading a diff between temporary files,
+    cleaning up on close"""
 
     def __init__(self, temp1, temp2, info1=None, info2=None, diff_cmd="diff", diff_opts=[]):
         self.readable = True

--- a/lib/vclib/__init__.py
+++ b/lib/vclib/__init__.py
@@ -81,8 +81,8 @@ class Repository:
     def openfile(self, path_parts, rev, options):
         """Open a file object to read file contents at a given path and revision.
 
-        The return value is a 2-tuple of containg the file object and revision
-        number in canonical form.
+        The return value is a 2-tuple of containg the binary file like object
+        and revision number in canonical form.
 
         The path is specified as a list of components, relative to the root
         of the repository. e.g. ["subdir1", "subdir2", "filename"]

--- a/lib/vclib/svn/svn_repos.py
+++ b/lib/vclib/svn/svn_repos.py
@@ -16,7 +16,7 @@ import vclib
 import os
 import os.path
 import tempfile
-from io import StringIO
+from io import BytesIO
 from urllib.parse import quote as _quote
 from svn import fs, repos, core, client, delta
 
@@ -251,7 +251,7 @@ class FileContentsPipe:
         chunk = None
         if not self._eof:
             if len is None:
-                buffer = StringIO()
+                buffer = BytesIO()
                 try:
                     while 1:
                         hunk = core.svn_stream_read(self._stream, 8192)

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -4021,7 +4021,8 @@ class DiffDescription:
     def _content_lines(self, side, propname):
         f = self.request.repos.openfile(side.path_comp, side.rev, {})[0]
         try:
-            lines = f.readlines()
+            lines = [lin.decode(self.request.repos.encoding, 'surrogateescape')
+                     for lin in f.readlines()]
         finally:
             f.close()
         return lines
@@ -4033,8 +4034,7 @@ class DiffDescription:
 
     def _prop_lines(self, side, propname):
         val = side.properties.get(propname, "")
-        # FIXME: dirty hack for Python 3: we need bytes as return value
-        return val.encode("utf-8", "surrogateescape").splitlines()
+        return val.splitlines()
 
     def _prop_fp(self, left, right, propname, diff_options):
         fn_left = self._temp_file(left.properties.get(propname))

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -4021,8 +4021,8 @@ class DiffDescription:
     def _content_lines(self, side, propname):
         f = self.request.repos.openfile(side.path_comp, side.rev, {})[0]
         try:
-            lines = [lin.decode(self.request.repos.encoding, 'surrogateescape')
-                     for lin in f.readlines()]
+            lines = [line.decode(self.request.repos.encoding, 'surrogateescape')
+                     for line in f.readlines()]
         finally:
             f.close()
         return lines


### PR DESCRIPTION
The problems were:

1. `get_line` parameter for `DiffDescription._get_diff()` should be a function that returns a list of `str`, but we passed a function that returns a list of `bytes`.
2. In `ezt.py`,  the type of return value `_get_value()` should not be a generator object, but there were some cases they were.

I couldn't determine which shoud be fixed in 2. case,  ezt.py or its caller.  However as the former is easier, I'd taken it.