### PR TITLE
issue #109: Introduce path encoding for repositories.

### DIFF
--- a/bin/cvsdbadmin
+++ b/bin/cvsdbadmin
@@ -19,6 +19,8 @@
 
 import sys
 import os
+import locale
+import codecs
 
 
 #########################################################################
@@ -171,6 +173,10 @@ if __name__ == "__main__":
         sys.stderr.write("ERROR: unknown command %s\n" % command)
         usage()
 
+    # setlocale and get its character encoding
+    locale.setlocale(locale.LC_CTYPE, "")
+    locale_encoding = codecs.lookup(locale.nl_langinfo(locale.CODESET)).name
+
     # get repository and path, and do the work
     root, path_parts = RootPath(args[2], quiet_level)
     rootpath = vclib.ccvs.canonicalize_rootpath(root)
@@ -190,7 +196,7 @@ if __name__ == "__main__":
 
         if command in ("rebuild", "update"):
             repository = vclib.ccvs.CVSRepository(
-                None, rootpath, None, cfg.utilities, 0, cfg.options.default_encoding
+                None, rootpath, None, cfg.utilities, 0, locale_encoding, locale_encoding
             )
             RecurseUpdate(db, repository, path_parts, command == "update", quiet_level)
     except KeyboardInterrupt:

--- a/conf/viewvc.conf.dist
+++ b/conf/viewvc.conf.dist
@@ -360,6 +360,28 @@
 ##---------------------------------------------------------------------------
 [options]
 
+## repos_locale: (Unix/Linux only) (this comment is tentative)
+## Specifies LC_CTYPE locale for repository paths on your server.
+## Repository paths specified incvs_roots and/or svn_roots can be
+## non-ascii paths represented in Unicode.  We assume the viewvc.conf
+## file content is encoded by the locale that specified by locale
+## environment variables when ViewVC starts.  However, repository paths
+## can be placed in the path encoded by some encoding other than
+## ViewVC's start up locale.  So it can be override this value per
+## repos root. This value should be valid locale that supported by
+## your system environment.  If this is not set, ViewVC uses the locale
+## on strarting.
+##
+## (Warning) If setlocale is not thread safe on your system and if
+## you use mod_wsgi in daemon mode, do not set this value.
+## Otherwise, you might experience unexpected crashes or errors.
+##
+## Examples:
+## repos_locale = en_US.UTF-8
+## repos_locale = Russian_Russia.1251
+##
+#repos_locale =
+
 ## root_as_url_component: Interpret the first path component in the URL
 ## after the script location as the root to use.  This is an
 ## alternative to using the "root=" query key. If ViewVC is configured
@@ -787,8 +809,10 @@
 ## paths, property names, and its own reserved property values using
 ## the UTF-8 encoding.  CVS makes no such promises.  Of course, file
 ## content versioned in these systems can use any arbitrary encoding.
+## If this is not specified, it is set to the encoding of the locale
+## specified by repos_locale
 ##
-#default_encoding = utf-8
+#default_encoding =
 
 ## detect_encoding: Should we attempt to automatically detect
 ## versioned file character encodings?  [Requires 'chardet' module,

--- a/conf/viewvc.conf.dist
+++ b/conf/viewvc.conf.dist
@@ -360,7 +360,7 @@
 ##---------------------------------------------------------------------------
 [options]
 
-## repos_locale: (Unix/Linux only) (this comment is tentative)
+## root_path_locale: (Unix/Linux only) (this comment is tentative)
 ## Specifies LC_CTYPE locale for repository paths on your server.
 ## Repository paths specified in cvs_roots and/or svn_roots can be
 ## non-ascii paths represented in Unicode.  We assume the viewvc.conf
@@ -377,10 +377,10 @@
 ## Otherwise, you might experience unexpected crashes or errors.
 ##
 ## Examples:
-## repos_locale = en_US.UTF-8
-## repos_locale = Russian_Russia.1251
+## root_path_locale = en_US.UTF-8
+## root_path_locale = Russian_Russia.1251
 ##
-#repos_locale =
+#root_path_locale =
 
 ## root_as_url_component: Interpret the first path component in the URL
 ## after the script location as the root to use.  This is an
@@ -810,7 +810,7 @@
 ## the UTF-8 encoding.  CVS makes no such promises.  Of course, file
 ## content versioned in these systems can use any arbitrary encoding.
 ## If this is not specified, it is set to the encoding of the locale
-## specified by repos_locale
+## specified by root_path_locale
 ##
 #default_encoding =
 

--- a/conf/viewvc.conf.dist
+++ b/conf/viewvc.conf.dist
@@ -362,7 +362,7 @@
 
 ## repos_locale: (Unix/Linux only) (this comment is tentative)
 ## Specifies LC_CTYPE locale for repository paths on your server.
-## Repository paths specified incvs_roots and/or svn_roots can be
+## Repository paths specified in cvs_roots and/or svn_roots can be
 ## non-ascii paths represented in Unicode.  We assume the viewvc.conf
 ## file content is encoded by the locale that specified by locale
 ## environment variables when ViewVC starts.  However, repository paths

--- a/conf/viewvc.conf.dist
+++ b/conf/viewvc.conf.dist
@@ -9,6 +9,10 @@
 
 ## THE FORMAT OF THIS CONFIGURATION FILE
 ##
+##    Important Note: ViewVC assumes that the encoding of its configuration
+##    files (such as this one) matches the locale of the environment in
+##    which it is running.
+##
 ##    This file is delineated by sections, specified in [brackets].  Within 
 ##    each section, are a number of configuration settings.  These settings
 ##    take the form of: name = value.  Values may be continued on the
@@ -360,21 +364,19 @@
 ##---------------------------------------------------------------------------
 [options]
 
-## root_path_locale: (Unix/Linux only) (this comment is tentative)
-## Specifies LC_CTYPE locale for repository paths on your server.
-## Repository paths specified in cvs_roots and/or svn_roots can be
-## non-ascii paths represented in Unicode.  We assume the viewvc.conf
-## file content is encoded by the locale that specified by locale
-## environment variables when ViewVC starts.  However, repository paths
-## can be placed in the path encoded by some encoding other than
-## ViewVC's start up locale.  So it can be override this value per
-## repos root. This value should be valid locale that supported by
-## your system environment.  If this is not set, ViewVC uses the locale
-## on strarting.
+## root_path_locale: (Unix/Linux only) Specifies the LC_CTYPE locale
+## for root paths on your server.  ViewVC will assume that root paths
+## specified in cvs_roots/svn_roots are encoded using the locale in
+## which ViewVC is running, but this may not be true for certain
+## systems.  Use this setting to help ViewVC convert root paths as
+## represented in its own configuration files to the encoding used by
+## the filesystem of the host server.  This is also used for showing
+## CVS's internal paths as string of the locale.  If set, this value
+## must be valid locale supported by your system environment.
 ##
-## (Warning) If setlocale is not thread safe on your system and if
-## you use mod_wsgi in daemon mode, do not set this value.
-## Otherwise, you might experience unexpected crashes or errors.
+## WARNING: If setlocale is not thread-safe on your system, setting
+## this option might cause problems when ViewVC runs under mod_wsgi in
+## daemon mode.
 ##
 ## Examples:
 ## root_path_locale = en_US.UTF-8
@@ -810,7 +812,7 @@
 ## the UTF-8 encoding.  CVS makes no such promises.  Of course, file
 ## content versioned in these systems can use any arbitrary encoding.
 ## If this is not specified, it is set to the encoding of the locale
-## specified by root_path_locale
+## specified by root_path_locale.
 ##
 #default_encoding =
 

--- a/lib/common.py
+++ b/lib/common.py
@@ -161,6 +161,11 @@ def get_current_lc_ctype():
     return locale_tuple_to_name(locale.getlocale(locale.LC_CTYPE))
 
 
+# Ensure setlocale() is called and get its value as default.
+locale.setlocale(locale.LC_CTYPE, "")
+DEFALT_LC_CTYPE = get_current_lc_ctype()
+
+
 def get_repos_encodings(cfg, root, do_overlay=False, preserve_cfg=False):
     """Set locale for the repository specified by ROOT, and get encodings.
 
@@ -186,8 +191,8 @@ def get_repos_encodings(cfg, root, do_overlay=False, preserve_cfg=False):
         return 'utf-8', tmp_cfg.options.default_encoding or 'utf-8'
 
     else:
-        repos_locale = tmp_cfg.options.repos_locale
-        if repos_locale and (repos_locale != get_current_lc_ctype()):
+        repos_locale = tmp_cfg.options.repos_locale or DEFALT_LC_CTYPE
+        if repos_locale != get_current_lc_ctype():
             locale.setlocale(locale.LC_CTYPE, repos_locale)
 
         path_encoding = codecs.lookup(locale.nl_langinfo(locale.CODESET)).name

--- a/lib/common.py
+++ b/lib/common.py
@@ -169,13 +169,13 @@ DEFALT_LC_CTYPE = get_current_lc_ctype()
 def get_repos_encodings(cfg, root, do_overlay=False, preserve_cfg=False):
     """Set locale for the repository specified by ROOT, and get encodings.
 
-    Check 'repos_locale' and 'default_encoding' for repository ROOT in
+    Check 'root_path_locale' and 'default_encoding' for repository ROOT in
     the config CFG, then set locale for Subversion's API, and return
     2-tuple of the encoding for the repository path on local file system
     and the default encordings for the content of the files in the
     repository.
 
-    If 'repos_locale' option value for the ROOT is not valid locale name,
+    If 'root_path_locale' option value for the ROOT is not valid locale name,
     locale.Error can be raised."""
 
     if do_overlay:
@@ -191,9 +191,9 @@ def get_repos_encodings(cfg, root, do_overlay=False, preserve_cfg=False):
         return 'utf-8', tmp_cfg.options.default_encoding or 'utf-8'
 
     else:
-        repos_locale = tmp_cfg.options.repos_locale or DEFALT_LC_CTYPE
-        if repos_locale != get_current_lc_ctype():
-            locale.setlocale(locale.LC_CTYPE, repos_locale)
+        root_path_locale = tmp_cfg.options.root_path_locale or DEFALT_LC_CTYPE
+        if root_path_locale != get_current_lc_ctype():
+            locale.setlocale(locale.LC_CTYPE, root_path_locale)
 
         path_encoding = codecs.lookup(locale.nl_langinfo(locale.CODESET)).name
         repos_encoding = cfg.options.default_encoding or path_encoding

--- a/lib/config.py
+++ b/lib/config.py
@@ -390,7 +390,7 @@ class Config:
         self.utilities.max_context = 10000
         self.utilities.cvsgraph = ""
 
-        self.options.repos_locale = None
+        self.options.root_path_locale = None
         self.options.root_as_url_component = 1
         self.options.allowed_views = ["annotate", "diff", "markup", "roots"]
         self.options.authorizer = None

--- a/lib/config.py
+++ b/lib/config.py
@@ -390,6 +390,7 @@ class Config:
         self.utilities.max_context = 10000
         self.utilities.cvsgraph = ""
 
+        self.options.repos_locale = None
         self.options.root_as_url_component = 1
         self.options.allowed_views = ["annotate", "diff", "markup", "roots"]
         self.options.authorizer = None
@@ -431,7 +432,7 @@ class Config:
         self.options.enable_syntax_coloration = 1
         self.options.tabsize = 8
         self.options.detect_encoding = 0
-        self.options.default_encoding = "utf-8"
+        self.options.default_encoding = None
         self.options.use_cvsgraph = 0
         self.options.cvsgraph_conf = "cvsgraph.conf"
         self.options.allowed_cvsgraph_useropts = []

--- a/lib/vclib/__init__.py
+++ b/lib/vclib/__init__.py
@@ -517,3 +517,38 @@ def check_path_access(repos, path_parts, pathtype=None, rev=None):
     if not pathtype:
         pathtype = repos.itemtype(path_parts, rev)
     return auth.check_path_access(repos.rootname(), path_parts, pathtype, rev)
+
+
+if sys.platform == "win32":
+    def _getfspath(path, encoding):
+        """Get path on local file system.
+
+        PATH should be a path represented in str. On system using posix path,
+        it returns a path represented in bytes. On Windows, returns PATH
+        itself."""
+
+        return path
+
+    def os_listdir(path, encoding):
+        "Wrapper for os.listdir, with different encoding from file system encoding"
+        return os.listdir(path)
+
+else:
+    def _getfspath(path, encoding):
+        """Get path on local file system.
+
+        PATH should be a path represented in str. On system using posix path,
+        it returns a path represented in bytes. On Windows, returns PATH
+        itself."""
+
+        return path.encode(encoding, "surrogateescape")
+
+    def os_listdir(path, encoding):
+        """Wrapper for os.listdir, with different encoding from
+        file system encoding."""
+
+        if isinstance(path, bytes):
+            return os.listdir(path)
+        path = _getfspath(path, encoding) if path else b"."
+        return [ent.decode(encoding, "surrogateescape")
+                for ent in os.listdir(path)]

--- a/lib/vclib/ccvs/__init__.py
+++ b/lib/vclib/ccvs/__init__.py
@@ -56,13 +56,16 @@ def find_root_in_parent(parent_path, rootname):
     return None
 
 
-def CVSRepository(name, rootpath, authorizer, utilities, use_rcsparse, encoding="utf-8"):
+def CVSRepository(name, rootpath, authorizer, utilities, use_rcsparse,
+                  content_encoding, path_encoding):
     rootpath = canonicalize_rootpath(rootpath)
     if use_rcsparse:
         from . import ccvs
 
-        return ccvs.CCVSRepository(name, rootpath, authorizer, utilities, encoding)
+        return ccvs.CCVSRepository(name, rootpath, authorizer, utilities,
+                                   content_encoding, path_encoding)
     else:
         from . import bincvs
 
-        return bincvs.BinCVSRepository(name, rootpath, authorizer, utilities, encoding)
+        return bincvs.BinCVSRepository(name, rootpath, authorizer, utilities,
+                                       content_encoding, path_encoding)

--- a/lib/vclib/svn/__init__.py
+++ b/lib/vclib/svn/__init__.py
@@ -79,17 +79,19 @@ def find_root_in_parent(parent_path, rootname):
     return None
 
 
-def SubversionRepository(name, rootpath, authorizer, utilities, config_dir, encoding="utf-8"):
+def SubversionRepository(name, rootpath, authorizer, utilities, config_dir,
+                         content_encoding, path_encoding):
     rootpath = canonicalize_rootpath(rootpath)
     if re.search(_re_url, rootpath):
         from . import svn_ra
 
         return svn_ra.RemoteSubversionRepository(
-            name, rootpath, authorizer, utilities, config_dir, encoding
+            name, rootpath, authorizer, utilities, config_dir, content_encoding
         )
     else:
         from . import svn_repos
 
         return svn_repos.LocalSubversionRepository(
-            name, rootpath, authorizer, utilities, config_dir, encoding
+            name, rootpath, authorizer, utilities, config_dir,
+            content_encoding, path_encoding
         )

--- a/lib/vclib/svn/svn_ra.py
+++ b/lib/vclib/svn/svn_ra.py
@@ -17,6 +17,7 @@ import os
 import tempfile
 from urllib.parse import quote as _quote
 
+from . import _strpath
 from .svn_repos import (
     Revision,
     SVNChangedPath,
@@ -27,7 +28,6 @@ from .svn_repos import (
     _path_parts,
     _rev2optrev,
     _split_revprops,
-    _to_str,
 )
 from svn import core, client, ra
 
@@ -115,14 +115,14 @@ class LogCollector:
         msg, author, date, revprops = _split_revprops(log_entry.revprops)
 
         # Changed paths have leading slashes
-        changed_paths = [_to_str(p) for p in paths.keys()]
+        changed_paths = [_strpath(p) for p in paths.keys()]
         changed_paths.sort(key=_sort_key_path)
         this_path = None
         if self.path in changed_paths:
             this_path = self.path
             change = paths[self.path.encode("utf-8", "surrogateescape")]
             if change.copyfrom_path:
-                this_path = _to_str(change.copyfrom_path)
+                this_path = _strpath(change.copyfrom_path)
         for changed_path in changed_paths:
             if changed_path != self.path:
                 # If a parent of our path was copied, our "next previous"
@@ -130,7 +130,7 @@ class LogCollector:
                 if (self.path.rfind(changed_path) == 0) and self.path[len(changed_path)] == "/":
                     change = paths[changed_path.encode("utf-8", "surrogateescape")]
                     if change.copyfrom_path:
-                        this_path = _to_str(change.copyfrom_path) + self.path[len(changed_path) :]
+                        this_path = _strpath(change.copyfrom_path) + self.path[len(changed_path) :]
         if self.show_all_logs or this_path:
             if self.access_check_func is None or self.access_check_func(self.path[1:], revision):
                 entry = Revision(
@@ -509,7 +509,7 @@ class RemoteSubversionRepository(vclib.Repository):
             )
             dirents = {}
             for name, dirent in tmp_dirents.items():
-                dirent_parts = path_parts + [_to_str(name)]
+                dirent_parts = path_parts + [_strpath(name)]
                 kind = dirent.kind
                 if (
                     kind == core.svn_node_dir or kind == core.svn_node_file
@@ -518,7 +518,7 @@ class RemoteSubversionRepository(vclib.Repository):
                 ):
                     lh_rev, c_rev = self._get_last_history_rev(dirent_parts, rev)
                     dirent.created_rev = lh_rev
-                    dirents[_to_str(name)] = dirent
+                    dirents[_strpath(name)] = dirent
             dirents_locks = [dirents, locks]
             self._dirent_cache[key] = dirents_locks
 
@@ -618,10 +618,10 @@ class RemoteSubversionRepository(vclib.Repository):
                     base_rev = revision - 1
 
                 # Check authz rules (sadly, we have to lie about the path type)
-                parts = _path_parts(_to_str(path))
+                parts = _path_parts(_strpath(path))
                 if vclib.check_path_access(self, parts, vclib.FILE, revision):
                     if is_copy and base_path and (base_path != path):
-                        parts = _path_parts(_to_str(base_path))
+                        parts = _path_parts(_strpath(base_path))
                         if not vclib.check_path_access(self, parts, vclib.FILE, base_rev):
                             is_copy = 0
                             base_path = None
@@ -629,10 +629,10 @@ class RemoteSubversionRepository(vclib.Repository):
                             found_unreadable = 1
                     changes.append(
                         SVNChangedPath(
-                            _to_str(path),
+                            _strpath(path),
                             revision,
                             pathtype,
-                            _to_str(base_path),
+                            _strpath(base_path),
                             base_rev,
                             action,
                             is_copy,
@@ -697,7 +697,7 @@ class RemoteSubversionRepository(vclib.Repository):
             old_path = results[old_rev]
         except KeyError:
             raise vclib.ItemNotFound(path)
-        old_path = _cleanup_path(_to_str(old_path))
+        old_path = _cleanup_path(_strpath(old_path))
         old_path_parts = _path_parts(old_path)
         # Check access (lying about path types)
         if not vclib.check_path_access(self, old_path_parts, vclib.FILE, old_rev):

--- a/lib/vclib/svn/svn_ra.py
+++ b/lib/vclib/svn/svn_ra.py
@@ -203,7 +203,7 @@ class RemoteSubversionRepository(vclib.Repository):
         self.auth = authorizer
         self.diff_cmd = utilities.diff or "diff"
         self.config_dir = config_dir or None
-        self.encoding = encoding
+        self.content_encoding = encoding
 
         # See if this repository is even viewable, authz-wise.
         if not vclib.check_root_access(self):
@@ -308,7 +308,7 @@ class RemoteSubversionRepository(vclib.Repository):
         # for this item.
         lockinfo = size_in_rev = None
         if path_type == vclib.FILE:
-            basename = path_parts[-1].encode(self.encoding, "surrogateescape")
+            basename = path_parts[-1].encode("utf-8", "surrogateescape")
             list_url = self._geturl(self._getpath(path_parts[:-1]))
             dirents, locks = client.svn_client_ls3(
                 list_url, _rev2optrev(rev), _rev2optrev(rev), 0, self.ctx
@@ -372,7 +372,7 @@ class RemoteSubversionRepository(vclib.Repository):
         if pairs:
             for pname in pairs[0][1].keys():
                 pvalue = pairs[0][1][pname]
-                pname, pvalue = _normalize_property(pname, pvalue, self.encoding)
+                pname, pvalue = _normalize_property(pname, pvalue, self.content_encoding)
                 if pname:
                     propdict[pname] = pvalue
         return propdict
@@ -411,7 +411,7 @@ class RemoteSubversionRepository(vclib.Repository):
             elif self.auth:
                 date, author, msg, revprops, changes = self._revinfo(revision)
             else:
-                author = _normalize_property_value(author, self.encoding)
+                author = _normalize_property_value(author, self.content_encoding)
 
             # Strip text if the caller doesn't want it.
             if not include_text:

--- a/lib/vclib/svn/svn_repos.py
+++ b/lib/vclib/svn/svn_repos.py
@@ -13,6 +13,7 @@
 "Version Control lib driver for locally accessible Subversion repositories"
 
 import vclib
+import sys
 import os
 import os.path
 import tempfile
@@ -369,9 +370,17 @@ class SVNChangedPath(vclib.ChangedPath):
 
 
 class LocalSubversionRepository(vclib.Repository):
-    def __init__(self, name, rootpath, authorizer, utilities, config_dir, encoding):
-        if not (os.path.isdir(rootpath) and os.path.isfile(os.path.join(rootpath, "format"))):
-            raise vclib.ReposNotFound(name)
+    def __init__(self, name, rootpath, authorizer, utilities, config_dir,
+                 content_encoding, path_encoding):
+        if sys.platform == 'win32':
+            if (not (os.path.isdir(rootpath)
+                and os.path.isfile(os.path.join(rootpath, "format")))):
+                raise vclib.ReposNotFound(name)
+        else:
+            rootpathb = rootpath.encode(path_encoding, 'surrogateescape')
+            if (not (os.path.isdir(rootpathb)
+                and os.path.isfile(os.path.join(rootpathb, b"format")))):
+                raise vclib.ReposNotFound(name)
 
         # Initialize some stuff.
         self.rootpath = rootpath
@@ -379,7 +388,7 @@ class LocalSubversionRepository(vclib.Repository):
         self.auth = authorizer
         self.diff_cmd = utilities.diff or "diff"
         self.config_dir = config_dir or None
-        self.content_encoding = encoding
+        self.content_encoding = content_encoding
 
         # See if this repository is even viewable, authz-wise.
         if not vclib.check_root_access(self):

--- a/lib/vclib/svn/svn_repos.py
+++ b/lib/vclib/svn/svn_repos.py
@@ -379,7 +379,7 @@ class LocalSubversionRepository(vclib.Repository):
         self.auth = authorizer
         self.diff_cmd = utilities.diff or "diff"
         self.config_dir = config_dir or None
-        self.encoding = encoding
+        self.content_encoding = encoding
 
         # See if this repository is even viewable, authz-wise.
         if not vclib.check_root_access(self):
@@ -542,7 +542,7 @@ class LocalSubversionRepository(vclib.Repository):
         propdict = {}
         for pname in proptable.keys():
             pvalue = proptable[pname]
-            pname, pvalue = _normalize_property(pname, pvalue, self.encoding)
+            pname, pvalue = _normalize_property(pname, pvalue, self.content_encoding)
             if pname:
                 propdict[pname] = pvalue
         return propdict
@@ -562,7 +562,7 @@ class LocalSubversionRepository(vclib.Repository):
             oldest_rev,
             include_text,
             self.config_dir,
-            self.encoding,
+            self.content_encoding,
         )
         return source, youngest_rev
 

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -46,6 +46,7 @@ from common import (
     _RCSDIFF_ERROR,
     TemplateData,
     _item,
+    get_repos_encodings,
 )
 import accept
 import config
@@ -259,6 +260,8 @@ class Request:
                 # Setup an Authorizer for this rootname and username
                 self.auth = setup_authorizer(cfg, self.username)
 
+                # get the encoding for the path and contents
+                path_encoding, content_encoding = get_repos_encodings(cfg, self.rootname)
                 # Create the repository object
                 try:
                     if roottype == "cvs":
@@ -269,11 +272,15 @@ class Request:
                             self.auth,
                             cfg.utilities,
                             cfg.options.use_rcsparse,
-                            cfg.options.default_encoding,
+                            content_encoding,
+                            path_encoding,
                         )
                         # required so that spawned rcs programs correctly expand
                         # $CVSHeader$
-                        os.environ["CVSROOT"] = self.rootpath
+                        if sys.platform == 'win32':
+                            os.environ["CVSROOT"] = self.rootpath
+                        else:
+                            os.environb[b"CVSROOT"] = self.rootpath.encode(path_encoding)
                     elif roottype == "svn":
                         self.rootpath = vclib.svn.canonicalize_rootpath(rootpath)
                         self.repos = vclib.svn.SubversionRepository(
@@ -282,7 +289,7 @@ class Request:
                             self.auth,
                             cfg.utilities,
                             cfg.options.svn_config_dir,
-                            cfg.options.default_encoding,
+                            content_encoding,
                         )
                     else:
                         raise vclib.ReposNotFound()
@@ -1019,10 +1026,6 @@ def generate_page(request, view_name, data, content_type=None):
     template.generate(server_fp, data)
 
 
-def transcode_path_for_display(path, encoding, errors="replace"):
-    return path.encode("utf-8", "surrogateescape").decode(encoding, errors)
-
-
 def nav_path(request):
     """Return current path as list of items with "name" and "href" members
 
@@ -1050,8 +1053,6 @@ def nav_path(request):
         path_parts.append(part)
         is_last = len(path_parts) == len(request.path_parts)
 
-        if request.roottype == "cvs":
-            part = transcode_path_for_display(part, request.repos.encoding)
         item = _item(name=request.server.escape(part), href=None)
 
         if not is_last or (is_dir and request.view_func is not view_directory):
@@ -1598,11 +1599,6 @@ def common_template_data(request, revision=None, mime_type=None):
 
     cfg = request.cfg
 
-    if request.roottype == "cvs":
-        disp_where = transcode_path_for_display(request.where, request.repos.encoding)
-    else:
-        disp_where = request.where
-
     # Initialize data dictionary members (sorted alphanumerically)
     data = TemplateData(
         {
@@ -1637,7 +1633,7 @@ def common_template_data(request, revision=None, mime_type=None):
             "view": _view_codes[request.view_func],
             "view_href": None,
             "vsn": __version__,
-            "where": request.server.escape(disp_where),
+            "where": request.server.escape(request.where),
         }
     )
 
@@ -2143,7 +2139,7 @@ def markup_or_annotate(request, is_annotate):
                     break
             encoding = detect_encoding(text_block)
         if not encoding:
-            encoding = request.repos.encoding
+            encoding = request.repos.content_encoding
 
         # Decode the file's lines from the detected encoding to Unicode.
         try:
@@ -2511,9 +2507,6 @@ def view_directory(request):
         if request.roottype == "cvs":
             if file.absent:
                 continue
-            disp_name = transcode_path_for_display(file.name, request.repos.encoding)
-        else:
-            disp_name = file.name
         if cfg.options.hide_errorful_entries and file.errors:
             continue
         row.rev = file.rev
@@ -2528,7 +2521,7 @@ def view_directory(request):
             row.short_log = lf.get(maxlen=cfg.options.short_log_len, htmlize=1)
         row.lockinfo = file.lockinfo
         row.anchor = request.server.escape(file.name)
-        row.name = request.server.escape(disp_name)
+        row.name = request.server.escape(file.name)
         row.pathtype = (file.kind == vclib.FILE and "file") or (file.kind == vclib.DIR and "dir")
         row.errors = file.errors
 
@@ -4021,7 +4014,7 @@ class DiffDescription:
     def _content_lines(self, side, propname):
         f = self.request.repos.openfile(side.path_comp, side.rev, {})[0]
         try:
-            lines = [line.decode(self.request.repos.encoding, 'surrogateescape')
+            lines = [line.decode(self.request.repos.content_encoding, 'surrogateescape')
                      for line in f.readlines()]
         finally:
             f.close()
@@ -4445,7 +4438,7 @@ def view_revision(request):
         undisplayable = is_undisplayable(revprops[name])
         if not undisplayable:
             lf = LogFormatter(
-                request, revprops[name].decode(request.repos.encoding, "backslashreplace")
+                request, revprops[name].decode(request.repos.content_encoding, "backslashreplace")
             )
             value = lf.get(maxlen=0, htmlize=1)
         else:
@@ -5267,6 +5260,9 @@ def list_roots(request):
 
     # Add the viewable Subversion roots
     for root in cfg.general.svn_roots.keys():
+        path_encoding, content_encoding = get_repos_encodings(cfg, root,
+                                                              do_overlay=True,
+                                                              preserve_cfg=True)
         auth = setup_authorizer(cfg, request.username, root)
         try:
             repos = vclib.svn.SubversionRepository(
@@ -5275,7 +5271,7 @@ def list_roots(request):
                 auth,
                 cfg.utilities,
                 cfg.options.svn_config_dir,
-                cfg.options.default_encoding,
+                content_encoding,
             )
             lastmod = None
             if cfg.options.show_roots_lastmod:
@@ -5304,6 +5300,9 @@ def list_roots(request):
 
     # Add the viewable CVS roots
     for root in cfg.general.cvs_roots.keys():
+        path_encoding, content_encoding = get_repos_encodings(cfg, root,
+                                                              do_overlay=True,
+                                                              preserve_cfg=True)
         auth = setup_authorizer(cfg, request.username, root)
         try:
             vclib.ccvs.CVSRepository(
@@ -5312,7 +5311,8 @@ def list_roots(request):
                 auth,
                 cfg.utilities,
                 cfg.options.use_rcsparse,
-                cfg.options.default_encoding,
+                content_encoding,
+                path_encoding,
             )
         except vclib.ReposNotFound:
             continue

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -5345,12 +5345,14 @@ def _parse_root_parent(pp):
 def expand_root_parents(cfg):
     """Expand the configured root parents into individual roots."""
 
+    path_encoding, _ = get_repos_encodings(cfg, None)
+
     # Each item in root_parents is a "directory [= context ]: repo_type" string.
     for pp in cfg.general.root_parents:
         path, context, repo_type = _parse_root_parent(pp)
 
         if repo_type == "cvs":
-            roots = vclib.ccvs.expand_root_parent(path)
+            roots = vclib.ccvs.expand_root_parent(path, path_encoding)
             if cfg.options.hide_cvsroot and "CVSROOT" in roots:
                 del roots["CVSROOT"]
             if context:
@@ -5361,7 +5363,7 @@ def expand_root_parents(cfg):
             else:
                 cfg.general.cvs_roots.update(roots)
         elif repo_type == "svn":
-            roots = vclib.svn.expand_root_parent(path)
+            roots = vclib.svn.expand_root_parent(path, path_encoding)
             if context:
                 fullroots = {}
                 for root, rootpath in roots.items():
@@ -5388,6 +5390,8 @@ def find_root_in_parents(cfg, path_parts, roottype):
     if path_parts[-1] == "CVSROOT" and cfg.options.hide_cvsroot:
         return None
 
+    path_encoding, _ = get_repos_encodings(cfg, None)
+
     for pp in cfg.general.root_parents:
         path, context, repo_type = _parse_root_parent(pp)
 
@@ -5409,9 +5413,11 @@ def find_root_in_parents(cfg, path_parts, roottype):
 
         rootpath = None
         if roottype == "cvs":
-            rootpath = vclib.ccvs.find_root_in_parent(path, rootname)
+            rootpath = vclib.ccvs.find_root_in_parent(path, rootname,
+                                                      path_encoding)
         elif roottype == "svn":
-            rootpath = vclib.svn.find_root_in_parent(path, rootname)
+            rootpath = vclib.svn.find_root_in_parent(path, rootname,
+                                                     path_encoding)
 
         if rootpath is not None:
             return fullroot, rootpath, remain

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -289,6 +289,7 @@ class Request:
                             cfg.utilities,
                             cfg.options.svn_config_dir,
                             content_encoding,
+                            path_encoding,
                         )
                     else:
                         raise vclib.ReposNotFound()
@@ -5269,6 +5270,7 @@ def list_roots(request):
                 cfg.utilities,
                 cfg.options.svn_config_dir,
                 content_encoding,
+                path_encoding,
             )
             lastmod = None
             if cfg.options.show_roots_lastmod:

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -33,7 +33,6 @@ import tempfile
 import time
 from operator import attrgetter
 import io
-import popen
 from urllib.parse import urlencode as _urlencode, quote as _quote
 
 # These modules come from our library (the stub has set up the path)
@@ -3252,8 +3251,7 @@ def view_cvsgraph_image(request):
     # os.environ['LD_LIBRARY_PATH'] = '/usr/lib:/usr/local/lib:/path/to/cvsgraph'
 
     rcsfile = request.repos.rcsfile(request.path_parts)
-    fp = popen.popen(
-        cfg.utilities.cvsgraph or "cvsgraph",
+    fp = request.repos.cvsgraph_popen(
         (
             "-c",
             cfg.path(cfg.options.cvsgraph_conf),
@@ -3287,8 +3285,7 @@ def view_cvsgraph(request):
 
     # Create an image map
     rcsfile = request.repos.rcsfile(request.path_parts)
-    fp = popen.popen(
-        cfg.utilities.cvsgraph or "cvsgraph",
+    fp = request.repos.cvsgraph_popen(
         (
             "-i",
             "-c",


### PR DESCRIPTION
This introduces per-repository path encoding.

It allows non-ascii repository root paths in locale encoding for both of CVS repositories and Subversion Repositories.  Also it is used relative paths from the repository root file paths in CVS repos to represent them as Unicode.

~~This is still work in progress,  at least I've not fixed the code to call cvsgraph, yet.~~
