### PR TITLE
issue #301: Fix content encoding handling on diff view and on patch.

### DIFF
--- a/lib/vclib/ccvs/bincvs.py
+++ b/lib/vclib/ccvs/bincvs.py
@@ -420,7 +420,8 @@ class BinCVSRepository(BaseCVSRepository):
     def revinfo(self, rev):
         raise vclib.UnsupportedFeature
 
-    def rawdiff(self, path_parts1, rev1, path_parts2, rev2, type, options={}):
+    def rawdiff(self, path_parts1, rev1, path_parts2, rev2, diff_type,
+                options={}, is_text=True):
         """see vclib.Repository.rawdiff docstring
 
         Option values recognized by this implementation:
@@ -432,7 +433,7 @@ class BinCVSRepository(BaseCVSRepository):
         if self.itemtype(path_parts2, rev2) != vclib.FILE:  # does auth-check
             raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts2)))
 
-        args = vclib._diff_args(type, options)
+        args = vclib._diff_args(diff_type, options)
         if options.get("ignore_keyword_subst", 0):
             args.append("-kk")
 
@@ -441,12 +442,12 @@ class BinCVSRepository(BaseCVSRepository):
             raise NotImplementedError("cannot diff across paths in cvs")
         args.extend(["-r" + rev1, "-r" + rev2, rcsfile])
 
-        fp = self.rcs_popen("rcsdiff", args, True)
+        fp = self.rcs_popen("rcsdiff", args, is_text)
 
         # Eat up the non-GNU-diff-y headers.
         while 1:
             line = fp.readline()
-            if not line or line[0:5] == "diff ":
+            if not line or line[0:5] in ("diff ", b"diff "):
                 break
         return fp
 

--- a/lib/vclib/ccvs/ccvs.py
+++ b/lib/vclib/ccvs/ccvs.py
@@ -124,7 +124,8 @@ class CCVSRepository(BaseCVSRepository):
             return filtered_revs[first : (first + limit)]
         return filtered_revs
 
-    def rawdiff(self, path_parts1, rev1, path_parts2, rev2, type, options={}):
+    def rawdiff(self, path_parts1, rev1, path_parts2, rev2, diff_type,
+                options={}, is_text=True):
         if self.itemtype(path_parts1, rev1) != vclib.FILE:  # does auth-check
             raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts1)))
         if self.itemtype(path_parts2, rev2) != vclib.FILE:  # does auth-check
@@ -141,9 +142,12 @@ class CCVSRepository(BaseCVSRepository):
         info1 = (self.rcsfile(path_parts1, root=1, v=0), r1.date, r1.string)
         info2 = (self.rcsfile(path_parts2, root=1, v=0), r2.date, r2.string)
 
-        diff_args = vclib._diff_args(type, options)
+        diff_args = vclib._diff_args(diff_type, options)
+        encoding = self.content_encoding if is_text else None
 
-        return vclib._diff_fp(temp1, temp2, info1, info2, self.utilities.diff or "diff", diff_args)
+        return vclib._diff_fp(temp1, temp2, info1, info2,
+                              self.utilities.diff or "diff", diff_args,
+                              encoding=encoding)
 
     def annotate(self, path_parts, rev=None, include_text=False):
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check

--- a/lib/vclib/svn/svn_ra.py
+++ b/lib/vclib/svn/svn_ra.py
@@ -426,7 +426,8 @@ class RemoteSubversionRepository(vclib.Repository):
     def revinfo(self, rev):
         return self._revinfo(rev, 1)
 
-    def rawdiff(self, path_parts1, rev1, path_parts2, rev2, type, options={}):
+    def rawdiff(self, path_parts1, rev1, path_parts2, rev2, diff_type,
+                options={}, is_text=True):
         p1 = self._getpath(path_parts1)
         p2 = self._getpath(path_parts2)
         r1 = self._getrev(rev1)
@@ -436,7 +437,8 @@ class RemoteSubversionRepository(vclib.Repository):
         if not vclib.check_path_access(self, path_parts2, vclib.FILE, rev2):
             raise vclib.ItemNotFound(path_parts2)
 
-        args = vclib._diff_args(type, options)
+        args = vclib._diff_args(diff_type, options)
+        encoding = self.content_encoding if is_text else None
 
         def _date_from_rev(rev):
             date, author, msg, revprops, changes = self._revinfo(rev)
@@ -447,7 +449,8 @@ class RemoteSubversionRepository(vclib.Repository):
             temp2 = cat_to_tempfile(self, p2, r2)
             info1 = p1, _date_from_rev(r1), r1
             info2 = p2, _date_from_rev(r2), r2
-            return vclib._diff_fp(temp1, temp2, info1, info2, self.diff_cmd, args)
+            return vclib._diff_fp(temp1, temp2, info1, info2, self.diff_cmd,
+                                  args, encoding=encoding)
         except core.SubversionException as e:
             if e.apr_err == vclib.svn.core.SVN_ERR_FS_NOT_FOUND:
                 raise vclib.InvalidRevision

--- a/lib/vclib/svn/svn_repos.py
+++ b/lib/vclib/svn/svn_repos.py
@@ -577,7 +577,8 @@ class LocalSubversionRepository(vclib.Repository):
     def revinfo(self, rev):
         return self._revinfo(rev, 1)
 
-    def rawdiff(self, path_parts1, rev1, path_parts2, rev2, type, options={}):
+    def rawdiff(self, path_parts1, rev1, path_parts2, rev2, diff_type,
+                options={}, is_text=True):
         p1 = self._getpath(path_parts1)
         p2 = self._getpath(path_parts2)
         r1 = self._getrev(rev1)
@@ -587,7 +588,8 @@ class LocalSubversionRepository(vclib.Repository):
         if not vclib.check_path_access(self, path_parts2, vclib.FILE, rev2):
             raise vclib.ItemNotFound(path_parts2)
 
-        args = vclib._diff_args(type, options)
+        args = vclib._diff_args(diff_type, options)
+        encoding = self.content_encoding if is_text else None
 
         def _date_from_rev(rev):
             date, author, msg, revprops, changes = self._revinfo(rev)
@@ -598,7 +600,8 @@ class LocalSubversionRepository(vclib.Repository):
             temp2 = temp_checkout(self, p2, r2)
             info1 = p1, _date_from_rev(r1), r1
             info2 = p2, _date_from_rev(r2), r2
-            return vclib._diff_fp(temp1, temp2, info1, info2, self.diff_cmd, args)
+            return vclib._diff_fp(temp1, temp2, info1, info2, self.diff_cmd,
+                                  args, encoding=encoding)
         except core.SubversionException as e:
             if e.apr_err == core.SVN_ERR_FS_NOT_FOUND:
                 raise vclib.InvalidRevision


### PR DESCRIPTION
In revision diff view, ViewVC should show the diff as UTF-8 encoded Unicode HTML, by transcoding if the file contents is encoded in some encoding other than UTF-8 or ASCII. On the other hand, with generate patch mode, ViewVC should provide a raw diff without transcoding.

Those were not done because vclib._diff_fp(), which is used in diff view without highlighting of intraline changes and generate patch mode, always decoded the file content as UTF-8.

With this commit, we add a new argument to specify the encoding to decode the diff stream, and make the code path to handle the diff content without decoding/encoding, includes vclib._diff_fp().

To accomplish it, we also add a new argument "is_text" to rawdiff() method in vclib.Repository base class and its discendants.

* lib/vclib/__init__.py (Repository.rawdiff): - Rename argument "type" to "diff_type", not to hide the "type" class. - Add new argument "is_text" to specify the stream returned by the method should be a decoded stream or raw bytes stream. (_diff_fp.__init__): Add new argument "encoding" which is used to decode (or not decode if it is None) the diff stream from diff utility. (_diff_fp.read, _diff_fp.readline, _check_process_errors): Fix to work with both of bytes and str stream.

* lib/vclib/ccvs/bincvs.py (BaseCVSRepository.rawdiff), lib/vclib/ccvs/ccvs.py (CCVSRepository.rawdiff), lib/vclib/svn/svn_ra.py (RemoteSubversionRepository.raw_diff), lib/vclib/svn/svn_repos.py (LocalSubversionRepository.rawdiff): Impliment the change of specification on base class.

* lib/viewvc.py (diff_parse_headers): Add new argument is_text to allow bytes stream for "fp". (view_patch): Handle the diff stream "fp" as bytes stream, without any decode/encode by Python. (DiffDescription._content_fp): Request diff stream as str explicitly. (DiffDescription._prop_fp): Request diff stream decoded with the repository's content encoding.