### PR TITLE
issue #303: vclib.Repository: make rootpath simple attribute.

### DIFF
--- a/lib/vclib/__init__.py
+++ b/lib/vclib/__init__.py
@@ -48,16 +48,19 @@ SORTBY_REV = 2  # sorted by revision, youngest first
 # ======================================================================
 #
 class Repository:
-    """Abstract class representing a repository."""
+    """Abstract class representing a repository.
+
+    In addtion to those methods defined here, instances of subclasses
+    should have attribute(s) below.
+
+    rootpath        (str) Hold the absolute path to the repository in
+                    the local file system."""
 
     def rootname(self):
         """Return the name of this repository."""
 
     def roottype(self):
         """Return the type of this repository (vclib.CVS, vclib.SVN, ...)."""
-
-    def rootpath(self):
-        """Return the location of this repository."""
 
     def authorizer(self):
         """Return the vcauth.Authorizer object associated with this

--- a/lib/vclib/ccvs/bincvs.py
+++ b/lib/vclib/ccvs/bincvs.py
@@ -59,9 +59,6 @@ class BaseCVSRepository(vclib.Repository):
     def rootname(self):
         return self.name
 
-    def rootpath(self):
-        return self.rootpath
-
     def roottype(self):
         return vclib.CVS
 

--- a/lib/vclib/svn/svn_ra.py
+++ b/lib/vclib/svn/svn_ra.py
@@ -227,9 +227,6 @@ class RemoteSubversionRepository(vclib.Repository):
     def rootname(self):
         return self.name
 
-    def rootpath(self):
-        return self.rootpath
-
     def roottype(self):
         return vclib.SVN
 

--- a/lib/vclib/svn/svn_repos.py
+++ b/lib/vclib/svn/svn_repos.py
@@ -403,9 +403,6 @@ class LocalSubversionRepository(vclib.Repository):
     def rootname(self):
         return self.name
 
-    def rootpath(self):
-        return self.rootpath
-
     def roottype(self):
         return vclib.SVN
 


### PR DESCRIPTION
In vclib.Repository abstract class, rootpath() was defined as a method, however its implementation in subclasses were all broken: each __init__() methods of subclasses substitute self.rootpath method with rootpath paramer value passed by caller.  Also users of vclib.Repository class already uses the value of Repository.rootpath instead of return value of Repository.rootpath().

So we turn Repository.rootpath method into required attribute.

* lib/vclib/__init__.py (Repository): Add description for required attribute(s) in doc string. (Repository.rootpath): Remove method definition.

* lib/vclib/ccvs/bincvs.py (BaseCVSRepository.rootpath): Remove method definition.

* lib/vclib/svn/svn_ra.py (RemoteSubversionRepository.rootpath): Remove method definition.

* lib/vclib/svn/svn_repos.py
  (LocalSubversionRepository.rootpath): Remove method definition.