### PR TITLE
enable_debuglines: An admin-accessible bit of debug tooling

### DIFF
--- a/conf/viewvc.conf.dist
+++ b/conf/viewvc.conf.dist
@@ -306,7 +306,6 @@
 ##
 #languages = en-us
 
-
 ##---------------------------------------------------------------------------
 [utilities]
 
@@ -376,7 +375,6 @@
 ## cvsgraph = /usr/local/bin/cvsgraph
 ##
 #cvsgraph =
-
 
 ##---------------------------------------------------------------------------
 [options]
@@ -941,6 +939,15 @@
 ## would prefer not to share.
 ##
 #stacktraces = 0
+
+## enable_debuglines: If set, ViewVC will add to the template data
+## dictionary information that could be useful for debugging.  The
+## standard ViewVC templates will use JavaScript to echo this debug
+## information to the console.
+##
+## WARNING: This should not be enabled in production.
+##
+#enable_debuglines = 0
 
 ##---------------------------------------------------------------------------
 [templates]

--- a/docs/template-authoring-guide.html
+++ b/docs/template-authoring-guide.html
@@ -123,6 +123,23 @@ td {
       of the configuration file.</td>
 </tr>
 <tr>
+  <td class="varname">debuglines</td>
+  <td class="vartype">list</td>
+  <td class="varnote">List of debugline (timestamped strings with debugging information
+      from the application) sorted by their timestamps.</td>
+</tr>
+<tr>
+  <td class="varname">debuglines.line</td>
+  <td class="vartype">string</td>
+  <td class="varnote">The text associated with the debugline.</td>
+</tr>
+<tr>
+  <td class="varname">debuglines.timestamp</td>
+  <td class="vartype">string</td>
+  <td class="varnote">Timestamp of when the debugline was added (as a floating point
+      number of seconds since the Epoch).</td>
+</tr>
+<tr>
   <td class="varname">docroot</td>
   <td class="vartype">string</td>
   <td class="varnote">URL of the static documents directory, generally used for
@@ -130,7 +147,7 @@ td {
       directory (which is typically relative to the template
       location).</td>
 </tr>
-<tr>
+<tr class="varlevel1">
   <td class="varname">download_href</td>
   <td class="vartype">string</td>
   <td class="varnote">ViewVC file contents download URL for the current resource.

--- a/lib/config.py
+++ b/lib/config.py
@@ -449,6 +449,7 @@ class Config:
         self.options.log_pagesextra = 3
         self.options.limit_changes = 100
         self.options.stacktraces = 0
+        self.options.enable_debuglines = 0
 
         self.templates.diff = None
         self.templates.directory = None

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -107,6 +107,7 @@ class Request:
     def __init__(self, server, cfg):
         self.server = server
         self.cfg = cfg
+        self.debuglines = []
 
         self.script_name = _normalize_path(server.getenv("SCRIPT_NAME", ""))
         self.browser = server.getenv("HTTP_USER_AGENT", "unknown")
@@ -135,6 +136,8 @@ class Request:
 
         if self.server.error is not None:
             raise ViewVCException(str(self.server.error), "400 Bad Request")
+
+        self.add_debugline("Here we go...")
         cfg = self.cfg
 
         # This function first parses the query string and sets the following
@@ -257,11 +260,14 @@ class Request:
                 cfg.overlay_root_options(self.rootname)
 
                 # Setup an Authorizer for this rootname and username
+                self.add_debugline("Setting up the authorizer")
                 self.auth = setup_authorizer(cfg, self.username)
 
                 # get the encoding for the path and contents
                 path_encoding, content_encoding = get_repos_encodings(cfg, self.rootname)
+
                 # Create the repository object
+                self.add_debugline("Selecting repository")
                 try:
                     if roottype == "cvs":
                         self.rootpath = vclib.ccvs.canonicalize_rootpath(rootpath)
@@ -303,6 +309,7 @@ class Request:
                 )
 
         if self.repos:
+            self.add_debugline("Opening repository")
             self.repos.open()
             vctype = self.repos.roottype()
             if vctype == vclib.SVN:
@@ -459,8 +466,11 @@ class Request:
 
         # If we need to redirect, do so.  Otherwise, handle our requested view.
         if needs_redirect:
-            self.server.redirect(self.get_url())
+            redirect_url = self.get_url()
+            self.add_debugline(f"Redirecting to {redirect_url}")
+            self.server.redirect(redirect_url)
         else:
+            self.add_debugline(f"Executing {self.view_func.__name__}()")
             self.view_func(self)
 
     def get_url(self, escape=0, partial=0, prefix=0, **args):
@@ -483,6 +493,19 @@ class Request:
         if prefix:
             result = f"{self.server.scheme}://{self.server.uri_host}{result}"
         return result
+
+    def add_debugline(self, debugline):
+        """Add to the set of debug line strings a new one.
+
+        NOTE: Be mindful about logging information provided by the user
+        that might exploit the script-ful nature of this feature.  For
+        example:
+
+           self.add_debugline('`); alert("hi"); //')
+        """
+
+        if self.cfg.options.enable_debuglines:
+            self.debuglines.append(_item(timestamp=time.time(), line=debugline))
 
     def get_form(self, **args):
         """Constructs a link to another ViewVC page just like the get_link
@@ -1039,8 +1062,15 @@ def get_writeready_server_file(
 
 
 def generate_page(request, view_name, data, content_type=None):
+    extra_debuglines = []
+    extra_debuglines.append(
+        _item(timestamp=time.time(), line="Fetching template for %s" % view_name)
+    )
     server_fp = get_writeready_server_file(request, content_type, "utf-8", is_text=True)
     template = get_view_template(request.cfg, view_name, request.language)
+    extra_debuglines.append(_item(timestamp=time.time(), line="Rendering page"))
+    if request.cfg.options.enable_debuglines:
+        data["debuglines"].extend(extra_debuglines)
     template.generate(server_fp, data)
 
 
@@ -1621,6 +1651,7 @@ def common_template_data(request, revision=None, mime_type=None):
             "annotate_href": None,
             "base_href": None,
             "cfg": cfg,
+            "debuglines": request.debuglines,
             "docroot": (
                 cfg.options.docroot is None
                 and request.script_name + "/" + docroot_magic_path

--- a/templates/classic/_footer.ezt
+++ b/templates/classic/_footer.ezt
@@ -13,5 +13,15 @@
 </tr>
 </table>
 
+[if-any debuglines]
+<script>
+  var d;
+  [for debuglines]
+  d = new Date([debuglines.timestamp] * 1000.0);
+  console.log(`${d.toISOString()} [[]ViewVC] [debuglines.line]`);
+  [end]
+</script>
+[end]
+
 </body>
 </html>

--- a/templates/default/_footer.ezt
+++ b/templates/default/_footer.ezt
@@ -5,6 +5,14 @@
 Powered by <a href="http://viewvc.org/">ViewVC [vsn]</a>
 [if-any rss_href]<br/><a href="[rss_href]" title="RSS 2.0 feed"><img src="[docroot]/images/feed-icon-16x16.jpg" class="vc_icon" alt="RSS 2.0 feed" /></a>[else]&nbsp;[end]
 </div>
-
+[if-any debuglines]
+<script>
+  var d;
+  [for debuglines]
+  d = new Date([debuglines.timestamp] * 1000.0);
+  console.log(`${d.toISOString()} [[]ViewVC] [debuglines.line]`);
+  [end]
+</script>
+[end]
 </body>
 </html>


### PR DESCRIPTION
* `conf/viewvc.conf.dist, lib/config.py (enable_debuglines)`: New configuration option.
* `lib/viewvc.py (Request.add_debugline)`: New.  Sprinkle a few invocations of this throughout.
* `templates/classic/_footer.ezt, templates/default/_footer.ezt`: Add logic to use JavaScript to log the debuglines to the console.
* `docs/template-authoring-guide.html`: Document the new template variables.
