### PR TITLE
1.1.x: Backport 3098a69

### DIFF
--- a/lib/vclib/svn/svn_repos.py
+++ b/lib/vclib/svn/svn_repos.py
@@ -17,7 +17,6 @@ import os
 import os.path
 import string
 import cStringIO
-import signal
 import time
 import tempfile
 import popen
@@ -367,22 +366,6 @@ class LocalSubversionRepository(vclib.Repository):
       raise vclib.ReposNotFound(name)
 
   def open(self):
-    # Register a handler for SIGTERM so we can have a chance to
-    # cleanup.  If ViewVC takes too long to start generating CGI
-    # output, Apache will grow impatient and SIGTERM it.  While we
-    # don't mind getting told to bail, we want to gracefully close the
-    # repository before we bail.
-    def _sigterm_handler(signum, frame, self=self):
-      sys.exit(-1)
-    try:
-      signal.signal(signal.SIGTERM, _sigterm_handler)
-    except ValueError:
-      # This is probably "ValueError: signal only works in main
-      # thread", which will get thrown by the likes of mod_python
-      # when trying to install a signal handler from a thread that
-      # isn't the main one.  We'll just not care.
-      pass
-
     # Open the repository and init some other variables.
     self.repos = repos.svn_repos_open(self.rootpath)
     self.fs_ptr = repos.svn_repos_fs(self.repos)


### PR DESCRIPTION
This is a cherry-pick of commit 3098a69 .
The current 1.1.x code is broken anyway:
```
  File "/usr/lib/viewvc/lib/vclib/svn/svn_repos.py", line 392, in _sigterm_handler
    sys.exit(-1)
NameError: global name 'sys' is not defined
```
You can see a full backtrace, although from an earlier version, at http://svn.savannah.gnu.org/viewvc/freefont/trunk/freefont/sfd/FreeSerif.sfd?view=log .