### PR TITLE
issue #326: Allow copy config.Config instance on Python 3.6

### DIFF
--- a/bin/standalone.py
+++ b/bin/standalone.py
@@ -23,7 +23,6 @@ import string
 import socket
 import select
 import base64
-import copy
 from urllib.parse import unquote as _unquote
 import http.server as _http_server
 
@@ -331,7 +330,7 @@ class ViewVCHTTPRequestHandler(_http_server.BaseHTTPRequestHandler):
         # XXX Other HTTP_* headers
 
         # make a one time cfg for a single request
-        ot_cfg = copy.deepcopy(cfg)
+        ot_cfg = cfg.copy()
         try:
             try:
                 viewvc.main(StandaloneServer(self), ot_cfg)

--- a/lib/common.py
+++ b/lib/common.py
@@ -18,7 +18,6 @@ import sys
 import io
 import locale
 import codecs
-import copy
 
 # Special type indicators for diff header processing and idiff return codes
 _RCSDIFF_IS_BINARY = "binary-diff"
@@ -179,7 +178,7 @@ def get_repos_encodings(cfg, root, do_overlay=False, preserve_cfg=False):
     locale.Error can be raised."""
 
     if do_overlay:
-        tmp_cfg = copy.deepcopy(cfg) if preserve_cfg else cfg
+        tmp_cfg = cfg.copy() if preserve_cfg else cfg
         tmp_cfg.overlay_root_options(root)
     else:
         tmp_cfg = cfg


### PR DESCRIPTION
Before Python 3.7, config.Config instance object cannot be copied by using copy.deepcopy() because it owns instance objects of configparser.ConfigParser as a member, which cannot be copied by using copy.deepcopy().

This is a workaround for it. It also reduces overhead of copy operation.

* lib/config.py
  (Config.copy):
   New function to hide how to copy this instance object.
  (CustomParser in Config.load_config):
   New private class.
  (Config.load_config):
   Use CustomParser instead of configparser.ConfigParser.

* lib/common.py (get_repos_encodings),
  bin/standalone.py (ViewVCHTTPRequestHandler.run_viewvc):
   Use above to copy config.Config instance.

* lib/common.py (),  bin/standalone.py ():
   Don't import unused "copy" module.

Found by: @kberry