### PR TITLE
issue 333: Listify configured forbidden paths/regexps

### DIFF
--- a/lib/vcauth/forbidden/__init__.py
+++ b/lib/vcauth/forbidden/__init__.py
@@ -19,7 +19,7 @@ class ViewVCAuthorizer(vcauth.GenericViewVCAuthorizer):
 
     def __init__(self, root_lookup_func, username, params={}):
         forbidden = params.get("forbidden", "")
-        self.forbidden = map(lambda x: x.strip(), filter(None, forbidden.split(",")))
+        self.forbidden = [x.strip() for x in forbidden.split(",") if x.strip()]
 
     def check_root_access(self, rootname):
         return 1

--- a/lib/vcauth/forbiddenre/__init__.py
+++ b/lib/vcauth/forbiddenre/__init__.py
@@ -28,7 +28,7 @@ class ViewVCAuthorizer(vcauth.GenericViewVCAuthorizer):
 
     def __init__(self, root_lookup_func, username, params={}):
         forbidden = params.get("forbiddenre", "")
-        self.forbidden = map(lambda x: _split_regexp(x.strip()), filter(None, forbidden.split(",")))
+        self.forbidden = [_split_regexp(x.strip()) for x in forbidden.split(",") if x.strip()]
 
     def _check_root_path_access(self, root_path):
         default = 1


### PR DESCRIPTION
Bare `map()` statements without a wrapping `list()` leave consumable iterables that don't survive multiple traversals.  Fix this oversight.

While here, also fix the problems caused with whitespace-only members of the input list, e.g.:

```
forbidden = matthew, mark,     , luke, john
```
