### PR TITLE
Issue #336: AttributeError: 'str' object has no attribute 'decode'

### DIFF
--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -4452,9 +4452,7 @@ def view_revision(request):
             continue
         undisplayable = is_undisplayable(revprops[name])
         if not undisplayable:
-            lf = LogFormatter(
-                request, revprops[name].decode(request.repos.content_encoding, "backslashreplace")
-            )
+            lf = LogFormatter(request, revprops[name])
             value = lf.get(maxlen=0, htmlize=1)
         else:
             # note non-utf8 property values


### PR DESCRIPTION
* `lib/viewvc.py (view_revision)`: Avoid decoding a property value we already know to be a unicode string.