### PR TITLE
issue #344: Fix symlinks in tar

### DIFF
--- a/lib/vclib/svn/svn_ra.py
+++ b/lib/vclib/svn/svn_ra.py
@@ -751,7 +751,8 @@ class RemoteSubversionRepository(vclib.Repository):
         url = self._geturl(path)
 
         # Symlinks must be files with the svn:special property set on them
-        # and with file contents which read "link SOME_PATH".
+        # and with file contents which read "link SOME_PATH" in UTF-8,
+        # even if file system encoding is not 'utf-8'.
         if path_type != vclib.FILE:
             return None
         pairs = client.svn_client_proplist2(url, _rev2optrev(rev), _rev2optrev(rev), 0, self.ctx)
@@ -764,6 +765,6 @@ class RemoteSubversionRepository(vclib.Repository):
         fp = SelfCleanFP(cat_to_tempfile(self, path, rev))
         pathspec = fp.readline()
         fp.close()
-        if pathspec[:5] != "link ":
+        if pathspec[:5] != b"link ":
             return None
-        return pathspec[5:]
+        return pathspec[5:].decode('utf-8')

--- a/lib/vclib/svn/svn_repos.py
+++ b/lib/vclib/svn/svn_repos.py
@@ -975,7 +975,8 @@ class LocalSubversionRepository(vclib.Repository):
         fsroot = self._getroot(rev)
 
         # Symlinks must be files with the svn:special property set on them
-        # and with file contents which read "link SOME_PATH".
+        # and with file contents which read "link SOME_PATH" in UTF-8,
+        # even if file system encoding is not 'utf-8'.
         if path_type != vclib.FILE:
             return None
         props = fs.node_proplist(fsroot, path)
@@ -989,6 +990,6 @@ class LocalSubversionRepository(vclib.Repository):
             pathspec, eof = core.svn_stream_readline(stream, b"\n")
         finally:
             core.svn_stream_close(stream)
-        if pathspec[:5] != "link ":
+        if pathspec[:5] != b"link ":
             return None
-        return pathspec[5:]
+        return pathspec[5:].decode('utf-8')

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -4323,7 +4323,7 @@ def generate_tarball(out, request, reldir, stack, dir_mtime=None):
                 mode,
                 file.date is not None and file.date or 0,
                 typeflag=b"2",
-                linkname=symlink_target,
+                linkname=symlink_target.encode('utf-8'),
             )
         else:
             filesize = request.repos.filesize(rep_path + [file.name], request.pathrev)


### PR DESCRIPTION
* lib/vclib/svn/svn_repos.py (LocalSubversionRepository.get_symlink_target): Fix type of pathspec.

* lib/vclib/svn/svn_ra.py (RemoteSubversionRepository.get_symlink_target): Fix type of pathspec.

* lib/viewvc.py (generate_tarball): pass symlink_target as bytes, explicitly.

Found by: @ddfourni1 on github