### PR TITLE
Partially revert 14e7719 to restore 1.2 root parent behavior

### DIFF
--- a/lib/vclib/ccvs/bincvs.py
+++ b/lib/vclib/ccvs/bincvs.py
@@ -37,7 +37,7 @@ def _path_join(path_parts):
 class BaseCVSRepository(vclib.Repository):
     def __init__(self, name, rootpath, authorizer, utilities,
                  content_encoding, path_encoding):
-        if not vclib.ccvs._is_cvsroot(rootpath, path_encoding):
+        if not os.path.isdir(vclib._getfspath(rootpath, path_encoding)):
             raise vclib.ReposNotFound(name)
 
         self.name = name


### PR DESCRIPTION
ViewVC has historically allowed as a "CVS root parent" both:

  - a directory in which distinct CVS repositories (each with their own `CVSROOT/` subdir) are stored.
  - a CVS "monorepo", which is a single repository but serves practically as a collection of many distinct projects.

A prior change partially limited this interpretation to only the former situation.  We restore support for the second here.
