### PR TITLE
issue #361: standalone.py: Use passlib for htpasswd support

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -61,6 +61,11 @@ Strongly recommended:
   * chardet character encoding detection library
       (https://chardet.github.io/)
 
+For htpasswd support on standalone server:
+
+  * passlib package
+      (https://pypi.org/project/passlib/) 
+
 There are a number of additional packages that you might need in order
 to enable additional features of ViewVC.  Please see the relevant
 sections of this document for details.

--- a/INSTALL
+++ b/INSTALL
@@ -61,11 +61,6 @@ Strongly recommended:
   * chardet character encoding detection library
       (https://chardet.github.io/)
 
-For htpasswd support on standalone server:
-
-  * passlib package
-      (https://pypi.org/project/passlib/) 
-
 There are a number of additional packages that you might need in order
 to enable additional features of ViewVC.  Please see the relevant
 sections of this document for details.
@@ -488,6 +483,13 @@ can modify the hostname and port to which it binds using the `--host`
 and `--port` command-line options.  You can also change the virtual
 path location from `/viewvc` to something else with the
 `--script-alias` command-line option.
+
+ViewVC standalone server supports basic authentication by specifying
+apache httpd compatible htpasswd file with `--htpasswd-file`
+command-line option. This feature needs external `passlib` package.
+
+  * passlib package
+      (https://pypi.org/project/passlib/)
 
 For a full listing of supported command-line options, run the
 standalone server with `--help`.

--- a/bin/standalone.py
+++ b/bin/standalone.py
@@ -433,7 +433,7 @@ Options:
 
   --htpasswd-file=FILE       Authenticate incoming requests, validating against
                              against FILE, which is an Apache HTTP Server
-                             htpasswd file.  (CRYPT only; no DIGEST support.)
+                             htpasswd file.
 
   --port=PORT (-p)           Listen on PORT.  [default: %(port)d]
 


### PR DESCRIPTION
The htpasswd support for standalone.py using crypt or fcrypt module was very limited, and crypt module itself has been obsoleted since Python 3.11.  So we use passlib[1] package available from PyPI.

[1] https://pypi.org/project/passlib/