### PR TITLE
issue 360: Introduce new "image" view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 install.sh
+**/__pycache__
 **/*.pyc
 **/*.conf
+.venv
+.vscode

--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Version 1.3.0 (released ??-???-????)
   * new 'root_path_locale' option (Tigris #500)
   * support Unicode root path both in CVS and Subversion (Tigris #500)
   * fix encoding problems on diff view and generating patch (#301)
+  * new 'image' view for limited as-is image display (#360)
 
 Version 1.2.3 (released 04-Jan-2023)
 

--- a/conf/viewvc.conf.dist
+++ b/conf/viewvc.conf.dist
@@ -399,8 +399,7 @@
 ## in this comma-delited list will not be served (or, will return an
 ## error on attempted access).
 ##
-## Valid items for this list include: "annotate", "co", "diff", "markup",
-## "roots", "tar".
+## Valid items for this list (and descriptions thereof) are as follows:
 ##
 ## ----------+---------------------------------------------------------
 ##    VIEW   |                       DESCRIPTION

--- a/conf/viewvc.conf.dist
+++ b/conf/viewvc.conf.dist
@@ -421,6 +421,12 @@
 ##           | two revisions of a versioned file in a variety of
 ##           | different user-selectable formats.
 ## ----------+---------------------------------------------------------
+##  image    | The 'image' view delivers the raw image content of a
+##           | versioned web-friendly image file, allowing it to be
+##           | displayed directly in the browser.  This view exists
+##           | primarily for the sake of the 'markup' view, which can
+##           | embed images in its output.
+## ----------+---------------------------------------------------------
 ##  markup   | The 'markup' view shows the contents of a single
 ##           | revision of a versioned file, with syntax highlighting
 ##           | where possible and enabled.  It can also optionally

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -3202,7 +3202,7 @@ def view_checkout(request):
         raise ViewVCException("Checkout view is disabled", "403 Forbidden")
     if request.pathtype != vclib.FILE:
         raise ViewVCException("Unsupported feature: checkout view on directory", "400 Bad Request")
-    return checkout_or_image(request)
+    return checkout_or_image(request, is_image_view=False)
 
 
 def view_image(request):
@@ -3212,7 +3212,7 @@ def view_image(request):
         raise ViewVCException("Image view is disabled", "403 Forbidden")
     if request.pathtype != vclib.FILE:
         raise ViewVCException("Unsupported feature: image view on directory", "400 Bad Request")
-    return checkout_or_image(request)
+    return checkout_or_image(request, is_image_view=True)
 
 
 def cvsgraph_make_reqopt(request, cfgname, queryparam, optvalue):


### PR DESCRIPTION
The "image" view behaves like the "co" view, but restricts itself to only serving up the content of web-friendly image files (JPEG, GIF, PNG).  It is disabled by default.

The "markup" view of such files will now prefer the "image" view when generated the ViewVC URL used as the value of the `<img src="..."` attribute, but will fallback to "co" if that's an allowed view and "image" is not.