### PR TITLE
Let py_compile decide where *.pyc files go.

### DIFF
--- a/viewvc-install
+++ b/viewvc-install
@@ -281,7 +281,7 @@ LEGEND
 
     # (Optionally) compile the file.
     if compile_it:
-        py_compile.compile(destdir_path, destdir_path + "c", dst_path)
+        py_compile.compile(destdir_path, None, dst_path)
 
 
 def install_tree(src_path, dst_path, is_optional, prompt_replace):


### PR DESCRIPTION
Since Python 3.2, _*.pyc_ files are put in a _\_\_pycache\_\__ directory, named with the Python release, etc.  They are no longer put next to their _*.py_ file as this code was assuming.