### PR TITLE
issue 370: Disallow patch view on directories

### DIFF
--- a/templates/default/diff.ezt
+++ b/templates/default/diff.ezt
@@ -16,7 +16,7 @@
       <option value="s" [is diff_format "s"]selected="selected"[end]>Side by Side</option>
     </select>
     <input type="submit" value="Show" />
-    (<a href="[patch_href]">Generate patch</a>)
+    [if-any patch_href](<a href="[patch_href]">Generate patch</a>)[end]
   </div>
 </form>
 


### PR DESCRIPTION
Avoid displaying the "Generate patch" link when looking at a (Subversion) directory's diff view.  And at the implementation of the patch view, raise a quick exception if that view is used with a non-file target.