### PR TITLE
INSTALL: Add RDBMS settings requirement for commits DB

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -512,7 +512,7 @@ Requires:
   * One of the following database systems:
       - MySQL 5.7+ (https://www.mysql.com/)
       - MariaDB 10.2+ (https://mariadb.org/)
-  * Allow to create 1020 bytes length index key:
+  * Support for large index keys:
       - (MySQL < 8.0, MariaDB < 10.3.1 only) innodb_large_prefix
         parameter is "on" ("on" by default)
       - innodb_page_size parameter >= 8k (default is 16k)

--- a/INSTALL
+++ b/INSTALL
@@ -512,6 +512,10 @@ Requires:
   * One of the following database systems:
       - MySQL 5.7+ (https://www.mysql.com/)
       - MariaDB 10.2+ (https://mariadb.org/)
+  * Allow to create 1020 bytes length index key:
+      - (MySQL < 8.0, MariaDB < 10.3.1 only) innodb_large_prefix
+        parameter is "on" ("on" by default)
+      - innodb_page_size parameter >= 8k (default is 16k)
   * One of the following Python MySQL connectors:
       - PyMySQL (https://pypi.org/project/PyMySQL/) [RECOMMENDED]
       - mysqlclient (https://pypi.org/project/mysqlclient/)


### PR DESCRIPTION
As I wrote in issue [#241 comment](https://github.com/viewvc/viewvc/issues/241#issuecomment-3109883560) we should describe DBMS parameter settings for large index key length.

Although those conditions are satisfied by default,  they can be changed not to be satisfied.