### PR TITLE
Begin a universal conversion to f-strings

### DIFF
--- a/bin/db/cvsdbadmin
+++ b/bin/db/cvsdbadmin
@@ -55,7 +55,7 @@ def UpdateFile(db, repository, path, update, quiet_level):
         else:
             commit_list = cvsdb.GetCommitListFromRCSFile(repository, path)
     except Exception as e:
-        print("[ERROR] %s" % (e))
+        print(f"[ERROR] {e}")
         return
 
     file = cvsdb.reencode("/".join(path))
@@ -63,11 +63,11 @@ def UpdateFile(db, repository, path, update, quiet_level):
     if update:
         if quiet_level < 1 or (quiet_level < 2 and len(commit_list)):
             printing = 1
-            print("[%s [%d new commits]]" % (file, len(commit_list)), end=" ")
+            print(f"[{file} [{len(commit_list)} new commits]]", end=" ")
     else:
         if quiet_level < 2:
             printing = 1
-            print("[%s [%d commits]]" % (file, len(commit_list)), end=" ")
+            print(f"[{file} [{len(commit_list)} commits]]", end=" ")
 
     # add the commits into the database
     for commit in commit_list:
@@ -104,14 +104,14 @@ def RootPath(path, quiet_level):
         if os.path.exists(os.path.join(p, "CVSROOT")):
             root = p
             if quiet_level < 2:
-                print("Using repository root `%s'" % root)
+                print(f"Using repository root `{root}'")
             break
 
         p, pdir = os.path.split(p)
         if not pdir:
             del path_parts[:]
             if quiet_level < 1:
-                print("Using repository root `%s'" % root)
+                print(f"Using repository root `{root}'")
                 print("Warning: CVSROOT directory not found.")
             break
 
@@ -125,13 +125,13 @@ def RootPath(path, quiet_level):
 def usage():
     cmd = os.path.basename(sys.argv[0])
     sys.stderr.write(
-        """\
+        f"""\
 Administer the ViewVC checkins database data for the CVS repository
 located at REPOS-PATH.
 
-Usage: 1. %s [[-q] -q] rebuild REPOS-PATH
-       2. %s [[-q] -q] update REPOS-PATH
-       3. %s [[-q] -q] purge REPOS-PATH
+Usage: 1. {cmd} [[-q] -q] rebuild REPOS-PATH
+       2. {cmd} [[-q] -q] update REPOS-PATH
+       3. {cmd} [[-q] -q] purge REPOS-PATH
 
 1.  Rebuild the commit database information for the repository located
     at REPOS-PATH, after first purging information specific to that
@@ -147,7 +147,6 @@ Use the -q flag to cause this script to be less verbose; use it twice to
 invoke a peaceful state of noiselessness.
 
 """
-        % (cmd, cmd, cmd)
     )
     sys.exit(1)
 
@@ -170,7 +169,7 @@ if __name__ == "__main__":
         usage()
     command = args[1].lower()
     if command not in ("rebuild", "update", "purge"):
-        sys.stderr.write("ERROR: unknown command %s\n" % command)
+        sys.stderr.write(f"ERROR: unknown command {command}\n")
         usage()
 
     # setlocale and get its character encoding
@@ -186,7 +185,7 @@ if __name__ == "__main__":
 
         if command in ("rebuild", "purge"):
             if quiet_level < 2:
-                print("Purging existing data for repository root `%s'" % root)
+                print(f"Purging existing data for repository root `{root}'")
             try:
                 db.PurgeRepository(root)
             except cvsdb.UnknownRepositoryError as e:

--- a/bin/db/loginfo-handler
+++ b/bin/db/loginfo-handler
@@ -117,19 +117,19 @@ def HeuristicArgParse(s, repository):
 
         if start == 0:
             if m is None:
-                error('Argument "%s" does not contain any revision numbers' % (s))
+                error(f'Argument "{s}" does not contain any revision numbers')
 
             directory, filename = FindLongestDirectory(s[: m.start()], repository)
             if directory is None:
-                error('Argument "%s" does not start with a valid directory' % (s))
+                error(f'Argument "{s}" does not start with a valid directory')
 
-            debug('Directory name is "%s"' % directory)
+            debug(f'Directory name is "{directory}"')
 
         else:
             if m is None:
                 warning(
-                    "Failed to interpret past position %i in the loginfo "
-                    'argument, leftover string is "%s"' % (start, s[start:])
+                    f"Failed to interpret past position {start} in the loginfo "
+                    f'argument, leftover string is "{s[start:]}"'
                 )
 
             filename = s[start : m.start()]
@@ -138,7 +138,7 @@ def HeuristicArgParse(s, repository):
 
         file_data_list.append((filename, old_version, new_version))
 
-        debug('File "%s", old revision %s, new revision %s' % (filename, old_version, new_version))
+        debug(f'File "{filename}", old revision {old_version}, new revision {new_version}')
 
         start = m.end()
 
@@ -185,7 +185,7 @@ def CvsNtArgParse(s, repository):
     file_data_list = []
     directory, pos = NextFile(s)
 
-    debug('Directory name is "%s"' % directory)
+    debug(f'Directory name is "{directory}"')
 
     while 1:
         fileinfo, pos = NextFile(s, pos)
@@ -194,14 +194,13 @@ def CvsNtArgParse(s, repository):
 
         m = _re_cvsnt_revisions.match(fileinfo)
         if m is None:
-            warning('Can\'t parse file information in "%s"' % fileinfo)
+            warning(f'Can\'t parse file information in "{fileinfo}"')
             continue
 
         file_data = m.group("filename", "old", "new")
         file_data_list.append(file_data)
 
-        debug('File "%s", old revision %s, new revision %s' % file_data)
-
+        debug('File "{filename}", old revision {old}, new revision {new}'.format(**m.groupdict()))
     return directory, file_data_list
 
 
@@ -261,10 +260,10 @@ if __name__ == "__main__":
     except KeyError:
         error("CVSROOT not in environment")
 
-    debug('Repository name is "%s"' % repository)
+    debug(f'Repository name is "{repository}"')
 
     argc = len(sys.argv)
-    debug("Got %d arguments:" % (argc))
+    debug(f"Got {argc} arguments:")
     debug(["   " + x for x in sys.argv])
 
     # if we have more than 3 arguments, we are likely using the
@@ -307,9 +306,9 @@ if __name__ == "__main__":
 
     repository = cvsdb.CleanRepository(repository)
 
-    debug("Repository: %s" % (repository))
-    debug("Directory: %s" % (directory))
-    debug("Files: %s" % (str(files)))
+    debug(f"Repository: {repository}")
+    debug(f"Directory: {directory}")
+    debug(f"Files: {files}")
 
     if files is None:
         debug("Not a checkin, nothing to do")

--- a/bin/db/svndbadmin
+++ b/bin/db/svndbadmin
@@ -307,20 +307,20 @@ def _rev2int(r):
     else:
         r = int(r)
         if r < 0:
-            raise ValueError("invalid revision '%d'" % (r))
+            raise ValueError(f"invalid revision '{r}'")
     return r
 
 
 def usage():
     cmd = os.path.basename(sys.argv[0])
     sys.stderr.write(
-        """\
+        f"""\
 Administer the ViewVC checkins database data for the Subversion repository
 located at REPOS-PATH.
 
-Usage: 1. %s [-v] rebuild REPOS-PATH
-       2. %s [-v] update REPOS-PATH [REV[:REV2]] [--force]
-       3. %s [-v] purge REPOS-PATH
+Usage: 1. {cmd} [-v] rebuild REPOS-PATH
+       2. {cmd} [-v] update REPOS-PATH [REV[:REV2]] [--force]
+       3. {cmd} [-v] purge REPOS-PATH
 
 1.  Rebuild the commit database information for the repository located
     at REPOS-PATH across all revisions, after first purging
@@ -341,7 +341,6 @@ Usage: 1. %s [-v] rebuild REPOS-PATH
 Use the -v flag to cause this script to give progress information as it works.
 
 """
-        % (cmd, cmd, cmd)
     )
     sys.exit(1)
 
@@ -368,7 +367,7 @@ if __name__ == "__main__":
 
     command = args[1].lower()
     if command not in ("rebuild", "update", "purge"):
-        sys.stderr.write("ERROR: unknown command %s\n" % command)
+        sys.stderr.write(f"ERROR: unknown command {command}\n")
         usage()
 
     revs = []
@@ -388,7 +387,7 @@ if __name__ == "__main__":
             if len(revs) == 1:
                 revs.append(revs[0])
         except ValueError:
-            sys.stderr.write(f"ERROR: invalid revision specification " f'"{sys.argv[3]}"\n')
+            sys.stderr.write(f'ERROR: invalid revision specification "{sys.argv[3]}"\n')
             usage()
     else:
         rev = None

--- a/bin/standalone.py
+++ b/bin/standalone.py
@@ -154,23 +154,19 @@ class ViewVCHTTPRequestHandler(_http_server.BaseHTTPRequestHandler):
                 self.send_header("Content-type", "text/html")
                 self.send_header("Location", new_url)
                 self.end_headers()
-                self.wfile.write(
-                    (
-                        """<html>
+                body = f"""<html>
 <head>
-<meta http-equiv="refresh" content="10; url=%s" />
+<meta http-equiv="refresh" content="10; url="{new_url}" />
 <title>Moved Temporarily</title>
 </head>
 <body>
 <h1>Redirecting to ViewVC</h1>
-<p>You will be automatically redirected to <a href="%s">ViewVC</a>.
+<p>You will be automatically redirected to <a href="{new_url}">ViewVC</a>.
    If this doesn't work, please click on the link above.</p>
 </body>
 </html>
 """
-                        % (new_url, new_url)
-                    ).encode("utf-8")
-                )
+                self.wfile.write(body.encode("utf-8"))
             else:
                 self.send_error(404)
         except IOError:  # ignore IOError: [Errno 32] Broken pipe
@@ -324,7 +320,7 @@ class ViewVCHTTPRequestHandler(_http_server.BaseHTTPRequestHandler):
                 if not self.wfile.closed:
                     self.wfile.flush()
         except SystemExit as status:
-            self.log_error("ViewVC exit status %s", str(status))
+            self.log_error(f"ViewVC exit status {status}")
         else:
             self.log_error("ViewVC exited ok")
 
@@ -334,7 +330,7 @@ class ViewVCHTTPServer(_http_server.HTTPServer):
 
     def __init__(self, host, port, callback):
         self.address = (host, port)
-        self.url = "http://%s:%d/" % (host, port)
+        self.url = f"http://{host}:{port}/"
         self.callback = callback
         _http_server.HTTPServer.__init__(self, self.address, self.handler)
 
@@ -361,9 +357,7 @@ class ViewVCHTTPServer(_http_server.HTTPServer):
         to avoid double fault.
         """
         sys.stderr.write("-" * 40 + "\n")
-        sys.stderr.write(
-            "Exception happened during processing of request from %s\n" % str(client_address)
-        )
+        sys.stderr.write(f"Exception happened during processing of request from {client_address}\n")
         import traceback
 
         traceback.print_exc()
@@ -418,7 +412,7 @@ def usage():
     host = clean_options.host
     script_alias = clean_options.script_alias
     sys.stderr.write(
-        """Usage: %(cmd)s [OPTIONS]
+        f"""Usage: {cmd} [OPTIONS]
 
 Run a simple, standalone HTTP server configured to serve up ViewVC requests.
 
@@ -434,13 +428,13 @@ Options:
   --help                     Show this usage message and exit.
 
   --host=HOSTNAME (-h)       Listen on HOSTNAME.  Required for access from a
-                             remote machine.  [default: %(host)s]
+                             remote machine.  [default: {host}]
 
   --htpasswd-file=FILE       Authenticate incoming requests, validating against
                              against FILE, which is an Apache HTTP Server
                              htpasswd file.
 
-  --port=PORT (-p)           Listen on PORT.  [default: %(port)d]
+  --port=PORT (-p)           Listen on PORT.  [default: {port}]
 
   --repository=PATH (-r)     Serve the Subversion or CVS repository located
                              at PATH.  This option may be used more than once.
@@ -449,18 +443,15 @@ Options:
                              to Apache HTTP Server's ScriptAlias directive).
                              For example, "--script-alias=repo/view" will serve
                              ViewVC at "http://HOSTNAME:PORT/repo/view".
-                             [default: %(script_alias)s]
+                             [default: {script_alias}]
 """
-        % locals()
     )
     sys.exit(0)
 
 
 def badusage(errstr):
     cmd = os.path.basename(sys.argv[0])
-    sys.stderr.write(
-        "ERROR: %s\n\nTry '%s --help' for detailed usage information.\n" % (errstr, cmd)
-    )
+    sys.stderr.write(f"ERROR: {errstr}\n\nTry '{cmd} --help' for detailed usage information.\n")
     sys.exit(1)
 
 
@@ -529,13 +520,13 @@ def main(argv):
             try:
                 options.port = int(opt_port)
             except ValueError:
-                raise BadUsage("Port '%s' is not a valid port number" % (opt_port))
+                raise BadUsage(f"Port '{opt_port}' is not a valid port number")
             if not options.port:
                 raise BadUsage("You must supply a valid port.")
         if opt_htpasswd_file is not None:
             if not os.path.isfile(opt_htpasswd_file):
                 raise BadUsage(
-                    "'%s' does not appear to be a valid htpasswd file." % (opt_htpasswd_file)
+                    f"'{opt_htpasswd_file}' does not appear to be a valid htpasswd file."
                 )
             if not has_passlib:
                 raise BadUsage(
@@ -548,7 +539,7 @@ def main(argv):
         if opt_config_file is not None:
             if not os.path.isfile(opt_config_file):
                 raise BadUsage(
-                    "'%s' does not appear to be a valid configuration file." % (opt_config_file)
+                    f"'{opt_config_file}' does not appear to be a valid configuration file."
                 )
             options.config_file = opt_config_file
         if opt_host is not None:
@@ -559,7 +550,7 @@ def main(argv):
             if "Development" not in options.repositories:
                 rootname = "Development"
             else:
-                rootname = "Repository%d" % (len(options.repositories.keys()) + 1)
+                rootname = f"Repository{len(options.repositories.keys()) + 1}"
             options.repositories[rootname] = repository
     except BadUsage as err:
         badusage(str(err))

--- a/lib/accept.py
+++ b/lib/accept.py
@@ -88,11 +88,11 @@ class _AcceptItem:
     def __str__(self):
         s = self.name
         if self.quality != 1.0:
-            s = "%s;q=%.3f" % (s, self.quality)
+            s = f"{s};q={self.quality:.3f}"
         if self.level != 0.0:
-            s = "%s;level=%.3f" % (s, self.level)
+            s = f"{s};level={self.level:.3f}"
         if self.charset:
-            s = "%s;charset=%s" % (s, self.charset)
+            s = f"{s};charset={self.charset}"
         return s
 
 

--- a/lib/common.py
+++ b/lib/common.py
@@ -30,18 +30,6 @@ class _item:
         vars(self).update(kw)
 
 
-# Python 3: workaround for cmp()
-def cmp(a, b):
-    if a is None and b is None:
-        return 0
-    if a is None:
-        return 1
-    if b is None:
-        return -1
-    assert type(a) is type(b)
-    return (a > b) - (a < b)
-
-
 class TemplateData:
     """A custom dictionary-like object that allows one-time definition
     of keys, and only value fetches and changes, and key deletions,
@@ -87,8 +75,8 @@ class ViewVCException(Exception):
 
     def __str__(self):
         if self.status:
-            return "%s: %s" % (self.status, self.msg)
-        return "ViewVC Unrecoverable Error: %s" % self.msg
+            return f"{self.status}: {self.msg}"
+        return f"ViewVC Unrecoverable Error: {self.msg}"
 
 
 def print_exception_data(server, exc_data):

--- a/lib/config.py
+++ b/lib/config.py
@@ -254,7 +254,7 @@ class Config:
         at all, return None.  And if it's an override section but not an
         allowed one, raise IllegalOverrideSection."""
 
-        cv = "%s-%s|" % (sectype, secspec)
+        cv = f"{sectype}-{secspec}|"
         lcv = len(cv)
         if section[:lcv] != cv:
             return None
@@ -333,7 +333,7 @@ class Config:
         # Figure out the authorizer by searching first for a per-root
         # override, then falling back to the base/vhost configuration.
         authorizer = None
-        root_options_section = "root-%s|options" % (rootname)
+        root_options_section = f"root-{rootname}|options"
         if self.parser.has_section(root_options_section) and self.parser.has_option(
             root_options_section, "authorizer"
         ):
@@ -348,12 +348,12 @@ class Config:
         # Dig up the parameters for the authorizer, starting with the
         # base/vhost items, then overlaying any root-specific ones we find.
         params = {}
-        authz_section = "authz-%s" % (authorizer)
+        authz_section = f"authz-{authorizer}"
         if hasattr(self, authz_section):
             sub_config = getattr(self, authz_section)
             for attr in dir(sub_config):
                 params[attr] = getattr(sub_config, attr)
-        root_authz_section = "root-%s|authz-%s" % (rootname, authorizer)
+        root_authz_section = f"root-{rootname}|authz-{authorizer}"
         for section in self.parser.sections():
             if section == root_authz_section:
                 for key, value in self.parser.items():
@@ -367,7 +367,7 @@ class Config:
         if authorizer is None:
             authorizer = self.options.authorizer
         if authorizer:
-            authz_section = "authz-%s" % (self.options.authorizer)
+            authz_section = f"authz-{self.options.authorizer}"
             if hasattr(self, authz_section):
                 sub_config = getattr(self, authz_section)
                 for attr in dir(sub_config):
@@ -497,9 +497,9 @@ class IllegalOverrideSection(ViewVCConfigurationError):
         self.override_type = override_type
 
     def __str__(self):
-        return "malformed configuration: illegal %s override section: %s" % (
-            self.override_type,
-            self.section_name,
+        return (
+            f"malformed configuration: illegal {self.override_type} "
+            f"override section: {self.section_name}"
         )
 
 
@@ -510,9 +510,8 @@ class MalformedRoot(ViewVCConfigurationError):
         self.value_given = value_given
 
     def __str__(self):
-        return "malformed configuration: '%s' uses invalid syntax: %s" % (
-            self.config_name,
-            self.value_given,
+        return (
+            f"malformed configuration: '{self.config_name}' uses invalid syntax: {self.value_given}"
         )
 
 

--- a/lib/dbi.py
+++ b/lib/dbi.py
@@ -49,7 +49,7 @@ def DateTimeFromTicks(ticks):
         t = time.gmtime(ticks)
     else:
         t = time.localtime(ticks)
-    return "%04d-%02d-%02d %02d:%02d:%02d" % t[:6]
+    return "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}".format(*t[:6])
 
 
 _re_datetime = re.compile(

--- a/lib/ezt.py
+++ b/lib/ezt.py
@@ -279,7 +279,7 @@ FORMAT_URL = "url"
 #
 _item = r'(?:"(?:[^\\"]|\\.)*"|[A-Za-z_][-\w.]*)'
 _arg = r'(?:"(?:[^\\"]|\\.)*"|[-\w.]+)'
-_re_parse = re.compile(r"(\r?\n)|\[(%s(?: +%s)*)\]|(\[\[\])|\[#[^\]]*\]" % (_item, _arg))
+_re_parse = re.compile(rf"(\r?\n)|\[({_item}(?: +{_arg})*)\]|(\[\[\])|\[#[^\]]*\]")
 
 _re_args = re.compile(r'"(?:[^\\"]|\\.)*"|[-\w.]+')
 
@@ -508,7 +508,7 @@ class Template:
                         )
 
         if stack:
-            raise UnclosedBlocksError("Block opened at line %s" % stack[-1][4], filename=filename)
+            raise UnclosedBlocksError(f"Block opened at line {stack[-1][4]}", filename=filename)
         return program
 
     def _execute(self, program, fp, ctx):
@@ -822,7 +822,7 @@ class Reader:
     """Abstract class which allows EZT to detect Reader objects."""
 
     def filename(self):
-        return "(%s does not provide filename() method)" % repr(self)
+        return f"({self!r} does not provide filename() method)"
 
 
 class _FileReader(Reader):

--- a/lib/sapi.py
+++ b/lib/sapi.py
@@ -169,7 +169,7 @@ class CgiServer(Server):
 
         extraheaders = ""
         for name, value in self._headers:
-            extraheaders = extraheaders + "%s: %s\r\n" % (name, value)
+            extraheaders = extraheaders + f"{name}: {value}\r\n"
 
         # The only way ViewVC pages and error messages are visible under
         # IIS is if a 200 error code is returned. Otherwise IIS instead
@@ -177,9 +177,9 @@ class CgiServer(Server):
         if status is None or (status[:3] != "304" and self._iis):
             status = ""
         else:
-            status = "Status: %s\r\n" % status
+            status = f"Status: {status}\r\n"
 
-        self.write_text("%sContent-Type: %s\r\n%s\r\n" % (status, content_type, extraheaders))
+        self.write_text(f"{status}Content-Type: {content_type}\r\n{extraheaders}\r\n")
 
     def redirect(self, url):
         if self._iis:
@@ -330,4 +330,4 @@ def fix_iis_path_info(server, path_info):
 
 
 def redirect_notice(url):
-    return 'This document is located <a href="%s">here</a>.' % (url)
+    return f'This document is located <a href="{url}">here</a>.'

--- a/lib/vclib/__init__.py
+++ b/lib/vclib/__init__.py
@@ -372,7 +372,7 @@ class InvalidRevision(Error):
         if revision is None:
             Error.__init__(self, "Invalid revision")
         else:
-            Error.__init__(self, "Invalid revision " + str(revision))
+            Error.__init__(self, f"Invalid revision {revision}")
 
 
 class NonTextualFileContents(Error):
@@ -382,7 +382,7 @@ class NonTextualFileContents(Error):
 class ExternalDiffError(Error):
     def __init__(self, returncode, mess):
         self.returncode = returncode
-        Error.__init__(self, "Diff terminated with exit code {0:d}: {1}".format(returncode, mess))
+        Error.__init__(self, f"Diff terminated with exit code {returncode:d}: {mess}")
 
 
 # ======================================================================
@@ -394,12 +394,12 @@ def _diff_args(type, options):
     args = []
     if type == CONTEXT:
         if "context" in options:
-            args.append("--context=%i" % options["context"])
+            args.append(f"--context={options['context']}")
         else:
             args.append("-c")
     elif type == UNIFIED:
         if "context" in options:
-            args.append("--unified=%i" % options["context"])
+            args.append(f"--unified={options['context']}")
         else:
             args.append("-u")
     elif type == SIDE_BY_SIDE:
@@ -495,7 +495,7 @@ class _diff_fp:
     def _label(self, info):
         path, date, rev = info
         date = date and time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(date))
-        return "%s\t%s\t%s" % (path, date, rev)
+        return f"{path}\t{date}\t{rev}"
 
     def _check_process_errors(self):
         """Check errors returned by subprocss. On error, raise an

--- a/lib/vclib/ccvs/bincvs.py
+++ b/lib/vclib/ccvs/bincvs.py
@@ -87,7 +87,7 @@ class BaseCVSRepository(vclib.Repository):
 
     def listdir(self, path_parts, rev, options):
         if self.itemtype(path_parts, rev) != vclib.DIR:  # does auth-check
-            raise vclib.Error("Path '%s' is not a directory." % (_path_join(path_parts)))
+            raise vclib.Error(f"Path '{_path_join(path_parts)}' is not a directory.")
 
         # Only RCS files (*,v) and subdirs are returned.
         data = []
@@ -160,13 +160,13 @@ class BaseCVSRepository(vclib.Repository):
 
     def isexecutable(self, path_parts, rev):
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts)))
+            raise vclib.Error(f"Path '{_path_join(path_parts)}' is not a file.")
         rcsfile = self.rcsfile(path_parts, 1)
         return os.access(self._getfspath(rcsfile), os.X_OK)
 
     def filesize(self, path_parts, rev):
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts)))
+            raise vclib.Error(f"Path '{_path_join(path_parts)}' is not a file.")
         return -1
 
     def cvsgraph_popen(self, cvsgraph_args, is_text=False, capture_err=True):
@@ -224,7 +224,7 @@ class BinCVSRepository(BaseCVSRepository):
             boolean. true to use the original keyword substitution values.
         """
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts)))
+            raise vclib.Error(f"Path '{_path_join(path_parts)}' is not a file.")
         if not rev or rev == "HEAD" or rev == "MAIN":
             rev_flag = "-p"
         else:
@@ -264,16 +264,16 @@ class BinCVSRepository(BaseCVSRepository):
                 tip_rev = self._get_tip_revision(full_name + ",v", rev)
                 used_rlog = 1
             if not (tip_rev and tip_rev.undead):
-                raise vclib.Error('Could not find non-dead revision preceding "%s"' % rev)
+                raise vclib.Error(f'Could not find non-dead revision preceding "{rev}"')
             fp = self.rcs_popen("co", ("-p" + tip_rev.undead.string, full_name))
             filename, revision = _parse_co_header(fp, self.content_encoding)
 
         if filename is None:
-            raise vclib.Error('Missing output from co (filename = "%s")' % full_name)
+            raise vclib.Error(f'Missing output from co (filename = "{full_name}")')
 
         if not _paths_eq(filename, full_name):
             raise vclib.Error(
-                'The filename from co ("%s") did not match (expected "%s")' % (filename, full_name)
+                f'The filename from co ("{filename}") did not match (expected "{full_name}")'
             )
 
         return fp, revision
@@ -296,7 +296,7 @@ class BinCVSRepository(BaseCVSRepository):
             lists of tag and branch names encountered in the directory
         """
         if self.itemtype(path_parts, rev) != vclib.DIR:  # does auth-check
-            raise vclib.Error("Path '%s' is not a directory." % (_path_join(path_parts)))
+            raise vclib.Error(f"Path '{_path_join(path_parts)}' is not a directory.")
 
         subdirs = options.get("cvs_subdirs", 0)
         entries_to_fetch = []
@@ -333,7 +333,7 @@ class BinCVSRepository(BaseCVSRepository):
         """
 
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts)))
+            raise vclib.Error(f"Path '{_path_join(path_parts)}' is not a file.")
 
         # Invoke rlog
         rcsfile = self.rcsfile(path_parts, 1)
@@ -403,7 +403,7 @@ class BinCVSRepository(BaseCVSRepository):
 
     def annotate(self, path_parts, rev=None, include_text=False):
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts)))
+            raise vclib.Error(f"Path '{_path_join(path_parts)}' is not a file.")
 
         from vclib.ccvs import blame
 
@@ -423,9 +423,9 @@ class BinCVSRepository(BaseCVSRepository):
           ignore_keyword_subst - boolean, ignore keyword substitution
         """
         if self.itemtype(path_parts1, rev1) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts1)))
+            raise vclib.Error(f"Path '{_path_join(path_parts1)}' is not a file.")
         if self.itemtype(path_parts2, rev2) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts2)))
+            raise vclib.Error(f"Path '{_path_join(path_parts2)}' is not a file.")
 
         args = vclib._diff_args(diff_type, options)
         if options.get("ignore_keyword_subst", 0):
@@ -840,7 +840,7 @@ def _parse_log_header(fp):
                     p1, p2, p3, msg = error.groups()
                     filename = p1 or p2 or p3
                     if not filename:
-                        raise vclib.Error("Could not get filename from CVSNT error:\n%s" % line)
+                        raise vclib.Error(f"Could not get filename from CVSNT error:\n{line}")
                     eof = _EOF_ERROR
                     break
 
@@ -1023,7 +1023,7 @@ def _file_log(revs, taginfo, lockinfo, cur_branch, filter):
             try:
                 view_tag = taginfo[filter]
             except KeyError:
-                raise vclib.Error('Invalid tag or revision number "%s"' % filter)
+                raise vclib.Error(f'Invalid tag or revision number "{filter}"')
         filtered_revs = []
 
         # only include revisions on the tag branch or it's parent branches
@@ -1116,7 +1116,7 @@ def _get_logs(repos, dir_path_parts, entries, view_tag, get_dirs):
                     break
 
                 # otherwise just error out
-                raise vclib.Error('Rlog output ended early. Expected RCS file "%s"' % file.path)
+                raise vclib.Error(f'Rlog output ended early. Expected RCS file "{file.path}"')
 
             # if rlog filename doesn't match current file and we already have an
             # error message about this file, move on to the next file
@@ -1127,14 +1127,14 @@ def _get_logs(repos, dir_path_parts, entries, view_tag, get_dirs):
                     continue
 
                 raise vclib.Error(
-                    "Error parsing rlog output. Expected RCS file %s"
-                    ", found %s" % (file and file.path, filename)
+                    f"Error parsing rlog output. Expected RCS file {file and file.path}, "
+                    f"found {filename}"
                 )
 
             # if we get an rlog error message, restart loop without advancing
             # chunk_idx cause there might be more output about the same file
             if eof == _EOF_ERROR:
-                file.errors.append("rlog error: %s" % msg)
+                file.errors.append(f"rlog error: {msg}")
                 continue
 
             tag = None
@@ -1254,7 +1254,7 @@ else:
         try:
             info = os.stat(vclib._getfspath(pathname, encoding))
         except os.error as e:
-            return None, ["stat error: %s" % e]
+            return None, [f"stat error: {e}"]
 
         kind = None
         errors = []
@@ -1285,10 +1285,10 @@ else:
 
             if info[stat.ST_UID] == _uid:
                 if ((mode >> 6) & mask) != mask:
-                    errors.append("error: path is not accessible to user %i" % _uid)
+                    errors.append(f"error: path is not accessible to user {_uid}")
             elif info[stat.ST_GID] == _gid:
                 if ((mode >> 3) & mask) != mask:
-                    errors.append("error: path is not accessible to group %i" % _gid)
+                    errors.append(f"error: path is not accessible to group {_gid}")
             # If the process running the web server is a member of
             # the group stat.ST_GID access may be granted.
             # so the fall back to os.access is needed to figure this out.

--- a/lib/vclib/ccvs/blame.py
+++ b/lib/vclib/ccvs/blame.py
@@ -248,8 +248,8 @@ class CVSParser(rcsparse.Sink):
             rcsfile = open(rcs_pathname, "rb")
         except Exception:
             raise RuntimeError(
-                "error: %s appeared to be under CVS control, "
-                "but the RCS file is inaccessible." % rcs_pathname
+                f"error: {rcs_pathname} appeared to be under CVS control, "
+                "but the RCS file is inaccessible."
             )
 
         rcsparse.parse(rcsfile, self)
@@ -409,7 +409,11 @@ class BlameSource:
     def __init__(self, rcs_file, opt_rev=None, include_text=False, encoding="utf-8"):
         # Parse the CVS file
         parser = CVSParser(encoding)
-        revision = parser.parse_cvs_file(rcs_file, opt_rev.encode(encoding))
+        if opt_rev is None:
+            opt_rev_encoded = None
+        else:
+            opt_rev_encoded = opt_rev.encode(encoding)
+        revision = parser.parse_cvs_file(rcs_file, opt_rev_encoded)
         count = len(parser.revision_map)
         lines = parser.extract_revision(revision)
         if len(lines) != count:

--- a/lib/vclib/ccvs/ccvs.py
+++ b/lib/vclib/ccvs/ccvs.py
@@ -50,7 +50,7 @@ class CCVSRepository(BaseCVSRepository):
             lists of tag and branch names encountered in the directory
         """
         if self.itemtype(path_parts, rev) != vclib.DIR:  # does auth-check
-            raise vclib.Error("Path '%s' is not a directory." % (_path_join(path_parts)))
+            raise vclib.Error(f"Path '{_path_join(path_parts)}' is not a directory.")
         entries_to_fetch = []
         for entry in entries:
             if vclib.check_path_access(self, path_parts + [entry.name], None, rev):
@@ -73,9 +73,9 @@ class CCVSRepository(BaseCVSRepository):
                         InfoSink(entry, rev, alltags, self.content_encoding),
                     )
                 except IOError as e:
-                    entry.errors.append("rcsparse error: %s" % e)
+                    entry.errors.append(f"rcsparse error: {e}")
                 except RuntimeError as e:
-                    entry.errors.append("rcsparse error: %s" % e)
+                    entry.errors.append(f"rcsparse error: {e}")
                 except rcsparse.RCSStopParser:
                     pass
 
@@ -100,7 +100,7 @@ class CCVSRepository(BaseCVSRepository):
             dictionary of Tag objects for all tags encountered
         """
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts)))
+            raise vclib.Error(f"Path '{_path_join(path_parts)}' is not a file.")
 
         path = self.rcsfile(path_parts, 1)
         sink = TreeSink(self.content_encoding)
@@ -127,9 +127,9 @@ class CCVSRepository(BaseCVSRepository):
 
     def rawdiff(self, path_parts1, rev1, path_parts2, rev2, diff_type, options={}, is_text=True):
         if self.itemtype(path_parts1, rev1) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts1)))
+            raise vclib.Error(f"Path '{_path_join(path_parts1)}' is not a file.")
         if self.itemtype(path_parts2, rev2) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts2)))
+            raise vclib.Error(f"Path '{_path_join(path_parts2)}' is not a file.")
 
         fd1, temp1 = tempfile.mkstemp()
         os.fdopen(fd1, "wb").write(self.openfile(path_parts1, rev1, {})[0].getvalue())
@@ -151,7 +151,7 @@ class CCVSRepository(BaseCVSRepository):
 
     def annotate(self, path_parts, rev=None, include_text=False):
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts)))
+            raise vclib.Error(f"Path '{_path_join(path_parts)}' is not a file.")
         source = blame.BlameSource(
             self._getfspath(self.rcsfile(path_parts, 1)), rev, include_text, self.content_encoding
         )
@@ -162,7 +162,7 @@ class CCVSRepository(BaseCVSRepository):
 
     def openfile(self, path_parts, rev, options):
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % (_path_join(path_parts)))
+            raise vclib.Error(f"Path '{_path_join(path_parts)}' is not a file.")
         path = self.rcsfile(path_parts, 1)
         sink = COSink(rev, self.content_encoding)
         rcsparse.parse(open(self._getfspath(path), "rb"), sink)
@@ -338,14 +338,12 @@ class TreeSink(rcsparse.Sink):
                         added = added + count
                         idx = idx + count
                     elif command:
-                        raise vclib.Error(
-                            "error while parsing deltatext: %s" % self._to_str(command)
-                        )
+                        raise vclib.Error(f"error while parsing deltatext: {self._to_str(command)}")
 
         if len(rev.number) == 2:
-            rev.next_changed = changed and "+%i -%i" % (deled, added)
+            rev.next_changed = changed and f"+{deled} -{added}"
         else:
-            rev.changed = changed and "+%i -%i" % (added, deled)
+            rev.changed = changed and f"+{added} -{deled}"
 
     def _to_str(self, b):
         if isinstance(b, bytes):

--- a/lib/vclib/ccvs/rcsparse/common.py
+++ b/lib/vclib/ccvs/rcsparse/common.py
@@ -235,8 +235,7 @@ class RCSExpected(RCSParseError):
     def __init__(self, got, wanted):
         RCSParseError.__init__(
             self,
-            "Unexpected parsing error in RCS file.\n"
-            "Expected token: %s, but saw: %s" % (wanted, got),
+            f"Unexpected parsing error in RCS file.\nExpected token: {wanted}, but saw: {got}",
         )
 
 
@@ -372,7 +371,7 @@ class _Parser:
         date_fields = [int(x) for x in date_fields]
         EPOCH = 1970
         if date_fields[0] < EPOCH:
-            raise ValueError("invalid year for revision %s" % (revision,))
+            raise ValueError(f"invalid year for revision {revision}")
         try:
             timestamp = calendar.timegm(
                 tuple(date_fields)
@@ -383,13 +382,7 @@ class _Parser:
                 )
             )
         except ValueError as e:
-            raise ValueError(
-                "invalid date for revision %s: %s"
-                % (
-                    revision,
-                    e,
-                )
-            )
+            raise ValueError(f"invalid date for revision {revision}: {e}")
 
         # Parse author
         #

--- a/lib/vclib/ccvs/rcsparse/debug.py
+++ b/lib/vclib/ccvs/rcsparse/debug.py
@@ -105,7 +105,7 @@ def time_file(fname):
 def _usage():
     print("This is normally a module for importing, but it has a couple")
     print("features for testing as an executable script.")
-    print("USAGE: %s COMMAND filename,v" % sys.argv[0])
+    print(f"USAGE: {sys.argv[0]} COMMAND filename,v")
     print("  where COMMAND is one of:")
     print('    dump: filename is "dumped" to stdout')
     print("    time: filename is parsed with the time written to stdout")

--- a/lib/vclib/ccvs/rcsparse/parse_rcs_file.py
+++ b/lib/vclib/ccvs/rcsparse/parse_rcs_file.py
@@ -38,13 +38,8 @@ class Logger:
         self.name = name
 
     def __call__(self, *args):
-        self.f.write(
-            "%s(%s)\n"
-            % (
-                self.name,
-                ", ".join(["%r" % arg for arg in args]),
-            )
-        )
+        arg_str = ", ".join([repr(arg) for arg in args])
+        self.f.write(f"{self.name}({arg_str})\n")
 
 
 class LoggingSink:
@@ -72,6 +67,6 @@ if __name__ == "__main__":
             if os.path.isfile(path) and path.endswith(",v"):
                 parse(open(path, "rb"), LoggingSink(sys.stdout))
             else:
-                sys.stderr.write("%r is being ignored.\n" % path)
+                sys.stderr.write(f"{path!r} is being ignored.\n")
     else:
         parse(sys.stdin, LoggingSink(sys.stdout))

--- a/lib/vclib/ccvs/rcsparse/run-tests.py
+++ b/lib/vclib/ccvs/rcsparse/run-tests.py
@@ -48,12 +48,12 @@ filelist.sort()
 all_tests_ok = 1
 
 for filename in filelist:
-    sys.stderr.write("%s: " % (filename,))
+    sys.stderr.write(f"{filename}: ")
     f = StringIO()
     try:
         parse(open(filename, "rb"), LoggingSink(f))
     except Exception as e:
-        sys.stderr.write("Error parsing file: %s!\n" % (e,))
+        sys.stderr.write(f"Error parsing file: {e}!\n")
         raise
         all_tests_ok = 0
     else:

--- a/lib/vclib/svn/svn_ra.py
+++ b/lib/vclib/svn/svn_ra.py
@@ -38,7 +38,7 @@ HAS_SUBVERSION_VERSION = (core.SVN_VER_MAJOR, core.SVN_VER_MINOR, core.SVN_VER_P
 if HAS_SUBVERSION_VERSION < MIN_SUBVERSION_VERSION:
     found_ver = ".".join([str(x) for x in HAS_SUBVERSION_VERSION])
     needs_ver = ".".join([str(x) for x in MIN_SUBVERSION_VERSION])
-    raise Exception("Subversion version %s is required (%s found)" % (needs_ver, found_ver))
+    raise Exception(f"Subversion version {needs_ver} is required ({found_ver} found)")
 
 
 def _sort_key_path(path):
@@ -254,7 +254,7 @@ class RemoteSubversionRepository(vclib.Repository):
     def openfile(self, path_parts, rev, options):
         path = self._getpath(path_parts)
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % path)
+            raise vclib.Error(f"Path '{path}' is not a file.")
         rev = self._getrev(rev)
         # rev here should be the last history revision of the URL
         fp = SelfCleanFP(cat_to_tempfile(self, path, rev))
@@ -264,7 +264,7 @@ class RemoteSubversionRepository(vclib.Repository):
     def listdir(self, path_parts, rev, options):
         path = self._getpath(path_parts)
         if self.itemtype(path_parts, rev) != vclib.DIR:  # does auth-check
-            raise vclib.Error("Path '%s' is not a directory." % path)
+            raise vclib.Error(f"Path '{path}' is not a directory.")
         rev = self._getrev(rev)
         entries = []
         dirents, locks = self._get_dirents(path, rev)
@@ -276,7 +276,7 @@ class RemoteSubversionRepository(vclib.Repository):
     def dirlogs(self, path_parts, rev, entries, options):
         path = self._getpath(path_parts)
         if self.itemtype(path_parts, rev) != vclib.DIR:  # does auth-check
-            raise vclib.Error("Path '%s' is not a directory." % path)
+            raise vclib.Error(f"Path '{path}' is not a directory.")
         rev = self._getrev(rev)
         dirents, locks = self._get_dirents(path, rev)
         for entry in entries:
@@ -377,7 +377,7 @@ class RemoteSubversionRepository(vclib.Repository):
     def annotate(self, path_parts, rev, include_text=False):
         path = self._getpath(path_parts)
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % path)
+            raise vclib.Error(f"Path '{path}' is not a file.")
         rev = self._getrev(rev)
         url = self._geturl(path)
 
@@ -460,7 +460,7 @@ class RemoteSubversionRepository(vclib.Repository):
     def filesize(self, path_parts, rev):
         path = self._getpath(path_parts)
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % path)
+            raise vclib.Error(f"Path '{path}' is not a file.")
         rev = self._getrev(rev)
         dirents, locks = self._get_dirents(self._getpath(path_parts[:-1]), rev)
         dirent = dirents.get(path_parts[-1], None)

--- a/lib/vclib/svn/svn_repos.py
+++ b/lib/vclib/svn/svn_repos.py
@@ -31,7 +31,7 @@ HAS_SUBVERSION_VERSION = (core.SVN_VER_MAJOR, core.SVN_VER_MINOR, core.SVN_VER_P
 if HAS_SUBVERSION_VERSION < MIN_SUBVERSION_VERSION:
     found_ver = ".".join([str(x) for x in HAS_SUBVERSION_VERSION])
     needs_ver = ".".join([str(x) for x in MIN_SUBVERSION_VERSION])
-    raise Exception("Subversion version %s is required (%s found)" % (needs_ver, found_ver))
+    raise Exception(f"Subversion version {needs_ver} is required ({found_ver} found)")
 
 
 def _allow_all(root, path, pool):
@@ -423,7 +423,7 @@ class LocalSubversionRepository(vclib.Repository):
     def openfile(self, path_parts, rev, options):
         path = self._getpath(path_parts)
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % path)
+            raise vclib.Error(f"Path '{path}' is not a file.")
         rev = self._getrev(rev)
         fsroot = self._getroot(rev)
         revision = str(_get_last_history_rev(fsroot, path))
@@ -433,7 +433,7 @@ class LocalSubversionRepository(vclib.Repository):
     def listdir(self, path_parts, rev, options):
         path = self._getpath(path_parts)
         if self.itemtype(path_parts, rev) != vclib.DIR:  # does auth-check
-            raise vclib.Error("Path '%s' is not a directory." % path)
+            raise vclib.Error(f"Path '{path}' is not a directory.")
         rev = self._getrev(rev)
         fsroot = self._getroot(rev)
         dirents = fs.dir_entries(fsroot, path)
@@ -448,7 +448,7 @@ class LocalSubversionRepository(vclib.Repository):
     def dirlogs(self, path_parts, rev, entries, options):
         path = self._getpath(path_parts)
         if self.itemtype(path_parts, rev) != vclib.DIR:  # does auth-check
-            raise vclib.Error("Path '%s' is not a directory." % path)
+            raise vclib.Error(f"Path '{path}' is not a directory.")
         fsroot = self._getroot(self._getrev(rev))
         rev = self._getrev(rev)
         for entry in entries:
@@ -554,7 +554,7 @@ class LocalSubversionRepository(vclib.Repository):
         path = self._getpath(path_parts)
         path_type = self.itemtype(path_parts, rev)  # does auth-check
         if path_type != vclib.FILE:
-            raise vclib.Error("Path '%s' is not a file." % path)
+            raise vclib.Error(f"Path '{path}' is not a file.")
         rev = self._getrev(rev)
         history = self._get_history(path, rev, path_type, 0, {"svn_cross_copies": 1})
         youngest_rev, youngest_path = history[0]
@@ -609,7 +609,7 @@ class LocalSubversionRepository(vclib.Repository):
     def filesize(self, path_parts, rev):
         path = self._getpath(path_parts)
         if self.itemtype(path_parts, rev) != vclib.FILE:  # does auth-check
-            raise vclib.Error("Path '%s' is not a file." % path)
+            raise vclib.Error(f"Path '{path}' is not a file.")
         fsroot = self._getroot(self._getrev(rev))
         return fs.file_length(fsroot, path)
 

--- a/tools/check-code-formatting
+++ b/tools/check-code-formatting
@@ -9,14 +9,23 @@
 # (scripts that reference Python in the shebang line, WSGI stubs,
 # etc.)
 
-echo "Checking code formatting..."
+# If the user passes a --fix flag, we should fix the files
+if [ "$1" = "--fix" ]; then
+    echo "Checking code formatting..."
+    CHECK_ARGS=""
+else
+    echo "Checking code formatting (read-only)..."
+    CHECK_ARGS="--check"
+fi
 PYFILES=`grep -rl '^#\(!.*/\|.*-\)python' --exclude=*.py .`
-black --line-length=100 --quiet --check . ${PYFILES} && flake8 . ${PYFILES}
+black --line-length=100 --quiet ${CHECK_ARGS} . ${PYFILES} && flake8 . ${PYFILES}
 if [ $? -eq 0 ]; then
     echo ""
     echo "Linting succeeded!"
 else
     echo ""
     echo "Linting failed."
-    echo "Try running 'black --line-length=100' on your problematic files."
+    if [ "$1" != "--fix" ]; then
+        echo "Trying running this script again with the --fix option."
+    fi
 fi

--- a/viewvc-install
+++ b/viewvc-install
@@ -114,7 +114,7 @@ def error(text, etype=None, evalue=None):
     """Print error TEXT to stderr, pretty printing the optional
     exception type and value (ETYPE and EVALUE, respective), and then
     exit the program with an errorful code."""
-    sys.stderr.write("\n[ERROR] %s\n" % (text))
+    sys.stderr.write(f"\n[ERROR] {text}\n")
     if etype:
         traceback.print_exception(etype, evalue, None, file=sys.stderr)
     sys.exit(1)
@@ -199,7 +199,7 @@ def install_file(src_path, dst_path, mode, subst_path_vars, prompt_replace, comp
             elif CLEAN_MODE == "false":
                 overwrite = 0
             else:
-                print("File %s exists and is different from source file." % (destdir_path))
+                print(f"File {destdir_path} exists and is different from source file.")
                 while 1:
                     name, ext = os.path.splitext(src_path)
                     if ext in BINARY_FILE_EXTS:
@@ -237,7 +237,7 @@ LEGEND
 
     assert overwrite is not None
     if not overwrite:
-        print("   preserved %s" % (dst_path))
+        print(f"   preserved {dst_path}")
         return
 
     # If we get here, we're creating or overwriting the existing file.
@@ -257,24 +257,24 @@ LEGEND
     if not os.path.exists(dst_parent):
         try:
             os.makedirs(dst_parent)
-            print("   created   %s%s" % (dst_parent, os.sep))
+            print(f"   created   {dst_parent}{os.sep}")
         except os.error as e:
             if e.errno == 17:  # EEXIST: file exists
                 return
             if e.errno == 13:  # EACCES: permission denied
-                error("You do not have permission to create directory %s" % (dst_parent))
-            error("Unknown error creating directory %s" % (dst_parent), OSError, e)
+                error(f"You do not have permission to create directory {dst_parent}")
+            error(f"Unknown error creating directory {dst_parent}", OSError, e)
 
     # Now, write the file contents to their destination.
     try:
-        exists = os.path.exists(destdir_path)
+        action_str = "replaced" if os.path.exists(destdir_path) else "installed"
         open(destdir_path, "wb").write(contents)
-        print("   %s %s" % (exists and "replaced " or "installed", dst_path))
+        print(f"   {action_str} {dst_path}")
     except IOError as e:
         if e.errno == 13:
             # EACCES: permission denied
-            error("You do not have permission to write file %s" % (dst_path))
-        error("Unknown error writing file %s" % (dst_path), IOError, e)
+            error(f"You do not have permission to write file {dst_path}")
+        error(f"Unknown error writing file {dst_path}", IOError, e)
 
     # Set the files's mode.
     os.chmod(destdir_path, mode)
@@ -298,7 +298,7 @@ def install_tree(src_path, dst_path, is_optional, prompt_replace):
     src_path = _actual_src_path(src_path)
     dst_path = os.path.join(ROOT_DIR, dst_path.replace("/", os.sep))
     if not os.path.isdir(src_path):
-        print("   skipping  %s" % (dst_path))
+        print(f"   skipping  {dst_path}")
         return
     destdir_path = os.path.join(DESTDIR + dst_path)
 
@@ -353,7 +353,7 @@ def install_tree(src_path, dst_path, is_optional, prompt_replace):
         elif CLEAN_MODE == "false":
             delete = 0
         else:
-            print("File %s does not belong in ViewVC %s." % (dst_path, version))
+            print(f"File {dst_path} does not belong in ViewVC {version}.")
             while 1:
                 temp = input("Do you want to [D]elete it, or [L]eave it as is? ")
                 temp = temp[0].lower()
@@ -367,16 +367,16 @@ def install_tree(src_path, dst_path, is_optional, prompt_replace):
 
         assert delete is not None
         if delete:
-            print("   deleted   %s" % (os.path.join(dst_path, fname)))
+            print(f"   deleted   {os.path.join(dst_path, fname)}")
             os.unlink(os.path.join(destdir_path, fname))
         else:
-            print("   preserved %s" % (os.path.join(dst_path, fname)))
+            print(f"   preserved {os.path.join(dst_path, fname)}")
 
 
 def usage_and_exit(errstr=None):
     stream = errstr and sys.stderr or sys.stdout
     stream.write(
-        """Usage: %s [OPTIONS]
+        f"""Usage: {os.path.basename(sys.argv[0])} [OPTIONS]
 
 Installs the ViewVC web-based version control repository browser.
 
@@ -400,10 +400,9 @@ Options:
                       for the appropriate action on a per-file basis.
 
 """
-        % (os.path.basename(sys.argv[0]))
     )
     if errstr:
-        stream.write("ERROR: %s\n\n" % (errstr))
+        stream.write(f"ERROR: {errstr}\n\n")
         sys.exit(1)
     else:
         sys.exit(0)
@@ -432,13 +431,12 @@ if __name__ == "__main__":
 
     # Print the header greeting.
     print(
-        """This is the ViewVC %s installer.
+        f"""This is the ViewVC {version} installer.
 
 It will allow you to choose the install path for ViewVC.  You will now
 be asked some installation questions.  Defaults are given in square brackets.
 Just hit [Enter] if a default is okay.
 """
-        % version
     )
 
     # Prompt for ROOT_DIR if none provided.
@@ -448,7 +446,7 @@ Just hit [Enter] if a default is okay.
             default = os.path.join(pf, "viewvc-" + version)
         else:
             default = "/usr/local/viewvc-" + version
-        temp = input("Installation path [%s]: " % (default)).strip()
+        temp = input(f"Installation path [{default}]: ").strip()
         print()
         if len(temp):
             ROOT_DIR = temp
@@ -459,7 +457,7 @@ Just hit [Enter] if a default is okay.
     if DESTDIR is None:
         default = ""
         temp = input(
-            "DESTDIR path (generally only used by package maintainers) [%s]: " % (default)
+            f"DESTDIR path (generally only used by package maintainers) [{default}]: "
         ).strip()
         print()
         if len(temp):
@@ -468,9 +466,10 @@ Just hit [Enter] if a default is okay.
             DESTDIR = default
 
     # Install the files.
-    print(
-        "Installing ViewVC to %s%s:" % (ROOT_DIR, DESTDIR and " (DESTDIR = %s)" % (DESTDIR) or "")
-    )
+    if DESTDIR:
+        print(f"Installing ViewVC to {ROOT_DIR} (DESTDIR = {DESTDIR}):")
+    else:
+        print(f"Installing ViewVC to {ROOT_DIR}:")
     for args in FILE_INFO_LIST:
         install_file(*args)
     for args in TREE_LIST:


### PR DESCRIPTION
As much as possible, use f-strings instead of %-formatting for string interpolation, being careful not to disturb MySQL and date/time formatting placeholders.  Selectively replace some string concatenation with f-strings, as well.

Unrelated drive-by fixes included, also:

- Remove unused `lib/common.py:cmp()` function
- Properly handle `lib/vclib/ccvs/ccvs.py:BlameSource.__init__(..., opt_rev=None)`