### PR TITLE
lib/viewvc.py: Trap an exception on checking pathrev.

### DIFF
--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -338,7 +338,10 @@ class Request:
 
             # Make sure path exists
             self.pathrev = pathrev = self.query_dict.get("pathrev")
-            self.pathtype = _repos_pathtype(self.repos, path_parts, pathrev)
+            try:
+                self.pathtype = _repos_pathtype(self.repos, path_parts, pathrev)
+            except vclib.InvalidRevision as e:
+                raise ViewVCException(f"{e}", "404 Not Found")
 
             if self.pathtype is None:
                 # Path doesn't exist, see if it could be an old-style ViewVC URL


### PR DESCRIPTION
When check the existence of the path in specific pathrev, ViewVC does not check the existence of pathrev passed by client.  Then if the revision does not exist, it causes double exception like:

```
  File "/home/futatuki/work/viewvc/lib/vclib/svn/svn_repos.py", line 862, in _getrev
    rev = int(rev)
          ^^^^^^^^
ValueError: invalid literal for int() with base 10: 'foo'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/futatuki/work/viewvc/lib/viewvc.py", line 5626, in main
    request.run_viewvc()
  File "/home/futatuki/work/viewvc/lib/viewvc.py", line 341, in run_viewvc
    self.pathtype = _repos_pathtype(self.repos, path_parts, pathrev)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/futatuki/work/viewvc/lib/viewvc.py", line 844, in _repos_pathtype
    return repos.itemtype(path_parts, rev)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/futatuki/work/viewvc/lib/vclib/svn/svn_repos.py", line 414, in itemtype
    rev = self._getrev(rev)
          ^^^^^^^^^^^^^^^^^
  File "/home/futatuki/work/viewvc/lib/vclib/svn/svn_repos.py", line 864, in _getrev
    raise vclib.InvalidRevision(rev)
vclib.InvalidRevision: Invalid revision foo
```

To avoid it, this patch adds a trap for InvalidRevision exception on checking pathrev.