### PR TITLE
A part of Issue #385: Drop sapi.CgiServer

### DIFF
--- a/bin/cgi/iis/viewvc.cgi
+++ b/bin/cgi/iis/viewvc.cgi
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*-python-*-
+#
+# Copyright (C) 1999-2025 The ViewCVS Group. All Rights Reserved.
+#
+# By using this file, you agree to the terms and conditions set forth in
+# the LICENSE.html file which can be found at the top level of the ViewVC
+# distribution or at http://viewvc.org/license-1.html.
+#
+# For more information, visit http://viewvc.org/
+#
+# -----------------------------------------------------------------------
+#
+# viewvc: View CVS/SVN repositories via a web browser
+#
+# -----------------------------------------------------------------------
+#
+# This is a teeny stub to launch the main ViewVC app. It checks the load
+# average, then loads the (precompiled) viewvc.py file and runs it.
+#
+# -----------------------------------------------------------------------
+#
+
+import sys
+import os
+from wsgiref.handlers import IISCGIHandler
+
+
+#########################################################################
+#
+# INSTALL-TIME CONFIGURATION
+#
+# These values will be set during the installation process. During
+# development, they will remain None.
+#
+
+LIBRARY_DIR = None
+CONF_PATHNAME = None
+
+
+#########################################################################
+
+# Adjust sys.path to include our library directory.
+if LIBRARY_DIR:
+    sys.path.insert(0, LIBRARY_DIR)
+else:
+    sys.path.insert(0, os.path.abspath(os.path.join(sys.argv[0], "../../../../lib")))
+import sapi
+import viewvc
+
+# If admins want nicer processes, here's the place to get them.
+#
+# try:
+#   os.nice(20) # bump the nice level of this process
+# except:
+#   pass
+
+
+def application(environ, start_response):
+    server = sapi.WsgiServer(environ, start_response)
+    cfg = viewvc.load_config(CONF_PATHNAME, server)
+    viewvc.main(server, cfg)
+    return []
+
+
+if __name__ == "__main__":
+    IISCGIHandler().run(application)

--- a/bin/cgi/iis/viewvc.cgi
+++ b/bin/cgi/iis/viewvc.cgi
@@ -48,13 +48,6 @@ else:
 import sapi
 import viewvc
 
-# If admins want nicer processes, here's the place to get them.
-#
-# try:
-#   os.nice(20) # bump the nice level of this process
-# except:
-#   pass
-
 
 def application(environ, start_response):
     server = sapi.WsgiServer(environ, start_response)

--- a/bin/cgi/viewvc.cgi
+++ b/bin/cgi/viewvc.cgi
@@ -23,6 +23,7 @@
 
 import sys
 import os
+from wsgiref.handlers import CGIHandler
 
 
 #########################################################################
@@ -54,6 +55,13 @@ import viewvc
 # except:
 #   pass
 
-server = sapi.CgiServer()
-cfg = viewvc.load_config(CONF_PATHNAME, server)
-viewvc.main(server, cfg)
+
+def application(environ, start_response):
+    server = sapi.WsgiServer(environ, start_response)
+    cfg = viewvc.load_config(CONF_PATHNAME, server)
+    viewvc.main(server, cfg)
+    return []
+
+
+if __name__ == "__main__":
+    CGIHandler().run(application)

--- a/lib/sapi.py
+++ b/lib/sapi.py
@@ -18,9 +18,7 @@
 import cgi
 
 
-# Global server object. It will be one of the following:
-#   1. an WsgiServer object
-#   (Historically, there was one more server object here, CgiServer)
+# Global server object.
 server = None
 
 

--- a/lib/sapi.py
+++ b/lib/sapi.py
@@ -202,57 +202,5 @@ class WsgiServer(Server):
         return ServerFile(self)
 
 
-def fix_iis_url(server, url):
-    """When a CGI application under IIS outputs a "Location" header with a url
-    beginning with a forward slash, IIS tries to optimise the redirect by not
-    returning any output from the original CGI script at all and instead just
-    returning the new page in its place. Because of this, the browser does
-    not know it is getting a different page than it requested. As a result,
-    The address bar that appears in the browser window shows the wrong location
-    and if the new page is in a different folder than the old one, any relative
-    links on it will be broken.
-
-    This function can be used to circumvent the IIS "optimization" of local
-    redirects. If it is passed a location that begins with a forward slash it
-    will return a URL constructed with the information in CGI environment.
-    If it is passed a URL or any location that doens't begin with a forward slash
-    it will return just argument unaltered.
-    """
-    if url[0] == "/":
-        if server.getenv("HTTPS") == "on":
-            dport = "443"
-            prefix = "https://"
-        else:
-            dport = "80"
-            prefix = "http://"
-        prefix = prefix + server.getenv("HTTP_HOST")
-        if server.getenv("SERVER_PORT") != dport:
-            prefix = prefix + ":" + server.getenv("SERVER_PORT")
-        return prefix + url
-    return url
-
-
-def fix_iis_path_info(server, path_info):
-    """Fix the PATH_INFO value in IIS"""
-    # If the viewvc cgi's are in the /viewvc/ folder on the web server and a
-    # request looks like
-    #
-    #      /viewvc/viewvc.cgi/myproject/?someoption
-    #
-    # The CGI environment variables on IIS will look like this:
-    #
-    #      SCRIPT_NAME  =  /viewvc/viewvc.cgi
-    #      PATH_INFO    =  /viewvc/viewvc.cgi/myproject/
-    #
-    # Whereas on Apache they look like:
-    #
-    #      SCRIPT_NAME  =  /viewvc/viewvc.cgi
-    #      PATH_INFO    =  /myproject/
-    #
-    # This function converts the IIS PATH_INFO into the nonredundant form
-    # expected by ViewVC
-    return path_info[len(server.getenv("SCRIPT_NAME", "")) :]
-
-
 def redirect_notice(url):
     return f'This document is located <a href="{url}">here</a>.'

--- a/viewvc-install
+++ b/viewvc-install
@@ -56,6 +56,7 @@ CLEAN_MODE = None
 #           boolean -- compile?)
 FILE_INFO_LIST = [
     ("bin/cgi/viewvc.cgi", "bin/cgi/viewvc.cgi", 0o0755, 1, 0, 0),
+    ("bin/cgi/iis/viewvc.cgi", "bin/cgi/iis/viewvc.cgi", 0o0755, 1, 0, 0),
     ("bin/wsgi/viewvc.wsgi", "bin/wsgi/viewvc.wsgi", 0o0755, 1, 0, 0),
     ("bin/wsgi/viewvc.fcgi", "bin/wsgi/viewvc.fcgi", 0o0755, 1, 0, 0),
     ("bin/standalone.py", "bin/standalone.py", 0o0755, 1, 0, 0),


### PR DESCRIPTION
Before dropping `cgi` module from lib/sapi.py,  I propose dropping sapi.CgiServer for simplify by using wsgiref.handler.CGIHandler and wsgiref.handler.IISCGIHandler in viewvc.cgi.

Although I've added bin/cgi/iis/viewvc.cgi for IIS server,  I've not tested.