### PR TITLE
issue #389: Swap r1 and r2 parameter on "diff view" link in "revision view"

### DIFF
--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -4596,7 +4596,7 @@ def view_revision(request):
                     view_func=view_diff,
                     where=path,
                     pathtype=change.pathtype,
-                    params={"pathrev": str(rev), "r1": str(rev), "r2": str(change.base_rev)},
+                    params={"pathrev": str(rev), "r1": str(change.base_rev), "r2": str(rev)},
                     escape=1,
                 )
 


### PR DESCRIPTION
See issue #389.

This is important for VCSs which do not have sort key for revision ID, like git.