### PR TITLE
issue 385: Drop dependency on the cgi module

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -39,8 +39,6 @@ Minimum requirements:
 
   * Python 3.6+
       (https://www.python.org/)
-  * (Only needs on Python 3.13+)legacy-cgi module
-      (https://pypi.org/project/legacy-cgi/)
 
 For CVS support:
 

--- a/bin/standalone.py
+++ b/bin/standalone.py
@@ -24,7 +24,6 @@ import string
 import socket
 import select
 import base64
-import cgi
 from urllib.parse import unquote as _unquote
 import http.server as _http_server
 
@@ -129,7 +128,7 @@ class StandaloneServer(sapi.Server):
         return ret
 
     def params(self):
-        return cgi.parse()
+        return sapi.cgi_parse()
 
     def write(self, s):
         self._out_fp.write(s)


### PR DESCRIPTION
As has been done many times in the past, implement a (scope-reduced) compatibility shim for cgi.parse() in order to avoid introducing another third party dependency.  Should we need a fuller CGI interface in the future, we can revisit this decision, but for now let's favor simplicity for ViewVC admins.