### PR TITLE
issue 408: Avoid raising an exception when closing a stream

### DIFF
--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -97,10 +97,15 @@ class TextIOWrapper_noclose(io.TextIOWrapper):
     close() is called or this object is destroyed."""
 
     def close(self):
-        if not self.closed:
-            self.closed = True
+        try:
             self.flush()
-            self.detach()
+        finally:
+            # Detach so finalization of this wrapper won't close the underlying
+            # server stream.
+            try:
+                self.detach()
+            except Exception:
+                pass
 
 
 class Request:

--- a/lib/viewvc.py
+++ b/lib/viewvc.py
@@ -99,13 +99,9 @@ class TextIOWrapper_noclose(io.TextIOWrapper):
     def close(self):
         try:
             self.flush()
-        finally:
-            # Detach so finalization of this wrapper won't close the underlying
-            # server stream.
-            try:
-                self.detach()
-            except Exception:
-                pass
+        except Exception:
+            pass
+        self.detach()
 
 
 class Request:


### PR DESCRIPTION
Users of lighttpd (e.g., per #408) report that after every ViewVC request is handled, the server logs this error:

```
Exception ignored while finalizing file <TextIOWrapper_noclose name='<ServerFile file>' encoding='utf-8'>:
AttributeError: attribute 'closed' of '_io.TextIOWrapper' objects is not writable
```

Rework TextIOWrapper_noclose.close() to avoid this.
